### PR TITLE
Add prefix table to configuration validators

### DIFF
--- a/app/code/community/Inovarti/Pagarme/Model/System/Config/Validator/ChargeProcessingFeeValidator.php
+++ b/app/code/community/Inovarti/Pagarme/Model/System/Config/Validator/ChargeProcessingFeeValidator.php
@@ -10,7 +10,7 @@ class Inovarti_Pagarme_Model_System_Config_Validator_ChargeProcessingFeeValidato
                 ->getCollection()
                 ->addFieldToFilter('charge_processing_fee', array('eq', '0'));
             $splitRuleCollection->getSelect()
-                ->join(array('marketplace_menu' => 'pagarme_marketplace_menu'),
+                ->join(array('marketplace_menu' => Mage::getConfig()->getTablePrefix() . 'pagarme_marketplace_menu'),
                     'main_table.recipient_id = marketplace_menu.recipient_id');
 
             $qtdRulesThatAreNotResponsibleForChargeProcessingFee = $splitRuleCollection->count();

--- a/app/code/community/Inovarti/Pagarme/Model/System/Config/Validator/LiableValidator.php
+++ b/app/code/community/Inovarti/Pagarme/Model/System/Config/Validator/LiableValidator.php
@@ -10,7 +10,7 @@ class Inovarti_Pagarme_Model_System_Config_Validator_LiableValidator extends Mag
                 ->getCollection()
                 ->addFieldToFilter('liable', array('eq', '0'));
             $splitRuleCollection->getSelect()
-                ->join(array('marketplace_menu' => 'pagarme_marketplace_menu'),
+                ->join(array('marketplace_menu' => Mage::getConfig()->getTablePrefix() . 'pagarme_marketplace_menu'),
                     'main_table.recipient_id = marketplace_menu.recipient_id');
 
             $qtdRulesThatAreNotResponsibleForChargeback = $splitRuleCollection->count();


### PR DESCRIPTION
Um erro ocorre ao salvar as configurações porque o método responsável por validá-las não tem o prefixo das tabelas, ou seja, caso o Magento tenha sido instalado com prefixo nas tabelas, não é possível salvar as configurações.