### PR TITLE
Fix for phone format

### DIFF
--- a/app/code/community/Inovarti/Pagarme/Helper/Data.php
+++ b/app/code/community/Inovarti/Pagarme/Helper/Data.php
@@ -49,8 +49,8 @@ class Inovarti_Pagarme_Helper_Data extends Mage_Core_Helper_Abstract
 	public function splitTelephone($telephone)
 	{
 		$telephone = Zend_Filter::filterStatic($telephone, 'Digits');
-		$ddd = $this->_iSubstr($telephone, 10, 2); //$ddd = substr($telephone, 0, 2);
-		$number = $this->_iSubstr($telephone, 8, 8); //$number = substr($telephone, 2);
+		$ddd = substr($telephone, 0, 2);
+		$number = substr($telephone, 2);
 		$data = array(
 			'ddd' => $ddd,
 			'number' => $number


### PR DESCRIPTION
In some cases, customers will try to insert a cellphone number in the same input for the phone number, and Magento allows that. Problem is, we always act like this phone contains only 10 digits, instead of 11. Bummer!

@rodrigoPgSup please take a look on this PR, it may affect your recent changes :wink: