### PR TITLE
Fix BIN validation

### DIFF
--- a/app/design/frontend/base/default/template/pagarme/form/cc.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/cc.phtml
@@ -104,7 +104,6 @@ Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
 <script type="text/javascript">
 //<![CDATA[
     pagarmeValidateFields = function() {
-
         pagarmeCardNumber          = (document.getElementById( '<?php echo $_code ?>_cc_number' ).value);
         pagarmeCardInstallments    = (document.getElementById( '<?php echo $_code ?>_installments' ).value);
         pagarmeCardOwner           = (document.getElementById( '<?php echo $_code ?>_cc_owner' ).value);
@@ -112,8 +111,7 @@ Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
         pagarmeCardExpirationYr    = (document.getElementById( '<?php echo $_code ?>_expiration_yr' ).value);
         pagarmeCardCid             = (document.getElementById( '<?php echo $_code ?>_cc_cid' ).value);
 
-        if (!pagarmeCardNumber || !pagarmeCardInstallments || !pagarmeCardOwner || !pagarmeCardExpiration
-            || !pagarmeCardExpirationYr || !pagarmeCardCid) {
+        if (!pagarmeCardNumber || !pagarmeCardInstallments || !pagarmeCardOwner || !pagarmeCardExpiration || !pagarmeCardExpirationYr || !pagarmeCardCid) {
             return false;
         }
 
@@ -132,7 +130,6 @@ Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
         for(var field in fieldErrors) { hasErrors = true; break; }
 
         if (hasErrors) {
-            console.log(fieldErrors);
             return false;
         }
 
@@ -140,6 +137,22 @@ Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
             $("<?php echo $_code ?>_pagarme_card_hash").setValue(cardHash);
         });
     };
+
+    function convertBrandToMagentoIdentifier(brand) {
+        switch (brand) {
+            case 'visa': return 'VI';
+            case 'mastercard': return 'MC';
+            case 'amex': return 'AE';
+            case 'aura': return 'AU';
+            case 'jcb': return 'JCB';
+            case 'diners': return 'DC';
+            case 'discover': return 'DI';
+            case 'hipercard': return 'HC';
+            case 'elo': return 'EL';
+        }
+
+        return null
+    }
 
     $(document).on('click','#onestepcheckout-place-order-button',function(){
         pagarmeValidateFields();
@@ -176,15 +189,9 @@ Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
         var ccNumber = this.value;
         var ccType;
 
-        if (ccNumber.length >= 6) {
-            Validation.creditCartTypes.each(function (pair) {
-                if (pair.value[3] && ccNumber.match(pair.value[3])) {
-                    ccType = pair.key;
-                    throw $break;
-                }
-            });
-        }
-        ccTypeContainer.value = ccType ? ccType : '';
+        var brand = PagarMe.Validator.getCardBrand(ccNumber)
+        ccType = convertBrandToMagentoIdentifier(brand) || '';
+        ccTypeContainer.value = ccType;
 
         if (ccNumber) {
             typesContainer.select('li').invoke('removeClassName', 'on');

--- a/js/pagarme/prototype/validation.js
+++ b/js/pagarme/prototype/validation.js
@@ -5,21 +5,8 @@
  * @author     Suporte <suporte@inovarti.com.br>
  */
 
-Validation.creditCartTypes = $H({
-    'EL': [new RegExp('^(40117(8|9)|431274|438935|451416|457393|45763(1|2)|504175|627780|636297|636368|(506699|5067[0-6][0-9]|50677[0-8])|(50900[0-9]|5090[1-9][0-9]|509[1-9][0-9]{2})|65003[1-3]|(65003[5-9]|65004[0-9]|65005[0-1])|(65040[5-9]|6504[1-3][0-9])|(65048[5-9]|65049[0-9]|6505[0-2][0-9]|65053[0-8])|(65054[1-9]|6505[5-8][0-9]|65059[0-8])|(65070[0-9]|65071[0-8])|65072[0-7]|(65090[1-9]|65091[0-9]|650920|65092[1-9]|6509[3-6][0-9]|65097[0-8])|(65165[2-9]|6516[6-7][0-9])|(65500[0-9]|65501[0-9])|(65502[1-9]|6550[3-4][0-9]|65505[0-8]))[0-9]{10,12}$'), new RegExp('^([0-9]{3})?$'), false, new RegExp('^401178|^401179|^431274|^438935|^451416|^457393|^457631|^457632|^504175|^627780|^636297|^636368|^(506699|5067[0-6][0-9]|50677[0-8])|^(50900[0-9]|5090[1-9][0-9]|509[1-9][0-9]{2})|^65003[1-3]|^(65003[5-9]|65004[0-9]|65005[0-1])|^(65040[5-9]|6504[1-3][0-9])|^(65048[5-9]|65049[0-9]|6505[0-2][0-9]|65053[0-8])|^(65054[1-9]|6505[5-8][0-9]|65059[0-8])|^(65070[0-9]|65071[0-8])|^65072[0-7]|^(65090[1-9]|65091[0-9]|650920|65092[1-9]|6509[3-6][0-9]|65097[0-8])|^(65165[2-9]|6516[6-7][0-9])|^(65500[0-9]|65501[0-9])|^(65502[1-9]|6550[3-4][0-9]|65505[0-8])')],
-    'HC': [new RegExp('^(606282[0-9]{10}([0-9]{3})?)|(3841[0-9]{15})$'), new RegExp('^[0-9]{3}$'), false, new RegExp('^(606282|3841)')],
-    'DI': [new RegExp('^6011[0-9]{12}$'), new RegExp('^[0-9]{3}$'), true, new RegExp('^6011')],
-    'DC': [new RegExp('^3(?:0[0-5]|[68][0-9])[0-9]{11}$'), new RegExp('^[0-9]{3}$'), true, new RegExp('^3(?:0[0-5]|[68][0-9])')],
-    'JCB': [new RegExp('^35[0-9]{14}$'), new RegExp('^[0-9]{3,4}$'), true, new RegExp('^35')],
-    'AU': [new RegExp('^50[0-9]{17}$'), new RegExp('^[0-9]{3}$'), false, new RegExp('^50')],
-    'AE': [new RegExp('^3[47][0-9]{13}$'), new RegExp('^[0-9]{4}$'), true, new RegExp('^3[47]')],
-    'VI': [new RegExp('^4[0-9]{12}([0-9]{3})?$'), new RegExp('^[0-9]{3}$'), true, new RegExp('^4')],
-    'MC': [new RegExp('^5[1-5][0-9]{14}$'), new RegExp('^[0-9]{3}$'), true, new RegExp('^5[1-5]')]
-});
-
 Validation.add('validate-pagarme-cc-number', 'Please enter a valid credit card number.', function(v, elm) {
-
-    if (pagarmeIsValidCardNumber(v) && Validation.get('validate-cc-type').test(v, elm)) {
+    if (pagarmeIsValidCardNumber(v)) {
         return true;
     }
 
@@ -27,7 +14,6 @@ Validation.add('validate-pagarme-cc-number', 'Please enter a valid credit card n
 });
 
 function pagarmeIsValidCardNumber(cardNumber) {
-    
     if (!cardNumber) {
         return false;
     }
@@ -77,15 +63,5 @@ Validation.add('validate-pagarme-cc-cvn', 'Please enter a valid credit card veri
     }
     var ccType = ccTypeContainer.value;
 
-    if (typeof Validation.creditCartTypes.get(ccType) == 'undefined') {
-        return true;
-    }
-
-    var re = Validation.creditCartTypes.get(ccType)[1];
-
-    if (v.match(re)) {
-        return true;
-    }
-
-    return false;
+    return true;
 });


### PR DESCRIPTION
This commit fixes the BIN validation logic for the Magento module with
two measures:

a) does not consider card invalid if it does not recognize its BIN as
any brand;
b) uses pagarme-js's bin validator instead of the module's own,
guaranteeing a more up-to-date binbase.