### PR TITLE
Corrigido erro de falta de dados na finalização do pedido

### DIFF
--- a/app/design/frontend/base/default/template/pagarme/form/cc.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/cc.phtml
@@ -103,7 +103,7 @@ Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
 <?php endif; ?>
 <script type="text/javascript">
 //<![CDATA[
-    function pagarmeValidateFields() {
+    pagarmeValidateFields = function() {
 
         pagarmeCardNumber          = (document.getElementById( '<?php echo $_code ?>_cc_number' ).value);
         pagarmeCardInstallments    = (document.getElementById( '<?php echo $_code ?>_installments' ).value);
@@ -139,7 +139,7 @@ Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
         pagarmeCreditCard.generateHash(function(cardHash) {
             $("<?php echo $_code ?>_pagarme_card_hash").setValue(cardHash);
         });
-    }
+    };
 
     $(document).on('click','#onestepcheckout-place-order-button',function(){
         pagarmeValidateFields();


### PR DESCRIPTION
Closes #25 Corrigido erro de falta de dados na finalização do pedido (pagarmeValidadeFields is not defined)

Magento 1.9.3.0
PHP 7.0.8
Tema rwd/default

Conforme explicado no tópico a seguir:
http://stackoverflow.com/questions/1812560/prototype-ajax-updater-eval-javascript-functions