### PR TITLE
Corrigido erro 500 durante a captura manual

### DIFF
--- a/app/code/community/Inovarti/Pagarme/Model/Abstract.php
+++ b/app/code/community/Inovarti/Pagarme/Model/Abstract.php
@@ -192,7 +192,7 @@ abstract class Inovarti_Pagarme_Model_Abstract extends Inovarti_Pagarme_Model_Sp
 
     public function getGrandTotalFromPayment(Mage_Sales_Model_Order_Payment $payment)
     {
-        return $payment->getOrder()->getQuote()->getGrandTotal();
+        return $payment->getOrder()->getGrandTotal();
     }
 
     /**


### PR DESCRIPTION
Closes #85 Corrigido erro 500 durante a captura manual (Call to a member function getGrandTotal()
on null)

Magento 1.9.3.0
PHP 7.0.8
Tema rwd/default