### PR TITLE
Corrigido erro de falta de parâmetros em Inovarti_Pagarme_Model_Cc

### DIFF
--- a/app/code/community/Inovarti/Pagarme/Model/Cc.php
+++ b/app/code/community/Inovarti/Pagarme/Model/Cc.php
@@ -35,12 +35,14 @@ class Inovarti_Pagarme_Model_Cc extends Inovarti_Pagarme_Model_Abstract
 
     public function authorize(Varien_Object $payment, $amount)
     {
-        $this->_place($payment, $amount, self::REQUEST_TYPE_AUTH_ONLY);
+        $this->_place($payment, $this->getGrandTotalFromPayment($payment), self::REQUEST_TYPE_AUTH_ONLY);
         return $this;
     }
 
     public function capture(Varien_Object $payment, $amount)
     {
+        $amount = $this->getGrandTotalFromPayment($payment);
+
         if ($payment->getPagarmeTransactionId()) {
             $this->_place($payment, $amount, self::REQUEST_TYPE_CAPTURE_ONLY);
             return $this;

--- a/app/code/community/Inovarti/Pagarme/Model/Cc.php
+++ b/app/code/community/Inovarti/Pagarme/Model/Cc.php
@@ -33,16 +33,14 @@ class Inovarti_Pagarme_Model_Cc extends Inovarti_Pagarme_Model_Abstract
         return $this;
     }
 
-    public function authorize(Varien_Object $payment)
+    public function authorize(Varien_Object $payment, $amount)
     {
-        $this->_place($payment, $this->getGrandTotalFromPayment($payment), self::REQUEST_TYPE_AUTH_ONLY);
+        $this->_place($payment, $amount, self::REQUEST_TYPE_AUTH_ONLY);
         return $this;
     }
 
-    public function capture(Varien_Object $payment)
+    public function capture(Varien_Object $payment, $amount)
     {
-        $amount = $this->getGrandTotalFromPayment($payment);
-
         if ($payment->getPagarmeTransactionId()) {
             $this->_place($payment, $amount, self::REQUEST_TYPE_CAPTURE_ONLY);
             return $this;


### PR DESCRIPTION
Closes #82 Corrigido erro de falta de parâmetros em métodos herdados, em Inovarti_Pagarme_Model_Cc::authorize e capture

Magento 1.9.3.0
PHP 7.0.8
Tema rwd/default