### PR TITLE
Manter Sempre a Versão de pagarme-php <= 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "pagarme/pagarme-php": "3.0.3"
+        "pagarme/pagarme-php": "3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8",


### PR DESCRIPTION
### Descrição

Manter a versão do SDK PHP o mais atualizada possível, sem editar sempre o arquivo `composer.json`.

### Número da Issue

#109 

### Testes Realizados

Executado `composer update` para validar a instalação correta.