### PR TITLE
Funcionalidade para selecionar cartões permitidos no painel administrativo

### DIFF
--- a/app/code/community/PagarMe/Core/Model/System/Config/Source/CreditCardBrands.php
+++ b/app/code/community/PagarMe/Core/Model/System/Config/Source/CreditCardBrands.php
@@ -9,8 +9,6 @@ class PagarMe_Core_Model_System_Config_Source_CreditCardBrands
      */
     public function toOptionArray()
     {
-
-
         return [
             [
                 'value' => 'visa',

--- a/app/code/community/PagarMe/Core/Model/System/Config/Source/CreditCardBrands.php
+++ b/app/code/community/PagarMe/Core/Model/System/Config/Source/CreditCardBrands.php
@@ -1,0 +1,49 @@
+<?php
+
+class PagarMe_Core_Model_System_Config_Source_CreditCardBrands
+{
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+
+
+        return [
+            [
+                'value' => 'visa',
+                'label' => 'Visa'
+            ],
+            [
+                'value' => 'mastercard',
+                'label' => 'Mastercard'
+            ],
+            [
+                'value' => 'amex',
+                'label' => 'Amex'
+            ],
+            [
+                'value' => 'hipercard',
+                'label' => 'Hipercard'
+            ],
+            [
+                'value' => 'aura',
+                'label' => 'Aura'
+            ],
+            [
+                'value' => 'jcb',
+                'label' => 'JCB'
+            ],
+            [
+                'value' => 'diners',
+                'label' => 'Diners'
+            ],
+            [
+                'value' => 'elo',
+                'label' => 'Elo'
+            ],
+        ];
+    }
+}

--- a/app/code/community/PagarMe/Core/etc/system.xml
+++ b/app/code/community/PagarMe/Core/etc/system.xml
@@ -71,6 +71,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </order_status_paid>
+                        <allowed_credit_card_brands translate="label">
+                            <label>Allowed Credit Card Brands</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <source_model>pagarme_core/system_config_source_creditCardBrands</source_model>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </allowed_credit_card_brands>
                     </fields>
                 </pagarme_settings>
             </groups>

--- a/tests/acceptance/ConfigureContext.php
+++ b/tests/acceptance/ConfigureContext.php
@@ -272,7 +272,6 @@ class ConfigureContext extends MinkContext
             $savedCreditCardsBrands
         );
 
-
         if (empty($this->creditCardListToAllow)) {
             $this->creditCardListToAllow = [
                 'visa',

--- a/tests/acceptance/ConfigureContext.php
+++ b/tests/acceptance/ConfigureContext.php
@@ -239,6 +239,97 @@ class ConfigureContext extends MinkContext
         );
     }
 
+    /**
+     * @Given a credit card list to allow
+     */
+    public function aCreditCardListToAllow()
+    {
+        $page = $this->getSession()->getPage();
+
+        $this->getSession()->wait(5000);
+        $select = $page->find(
+            'css',
+            '#payment_pagarme_settings_allowed_credit_card_brands'
+        );
+
+        $allCreditCardBrands = [
+            'visa',
+            'mastercard',
+            'amex',
+            'hipercard',
+            'aura',
+            'jcb',
+            'diners',
+            'elo'
+        ];
+
+        $savedCreditCardsBrands = explode(',', \Mage::getStoreConfig(
+            'payment/pagarme_settings/allowed_credit_card_brands'
+        ));
+
+        $this->creditCardListToAllow = array_diff(
+            $allCreditCardBrands,
+            $savedCreditCardsBrands
+        );
+
+
+        if (empty($this->creditCardListToAllow)) {
+            $this->creditCardListToAllow = [
+                'visa',
+                'amex',
+                'aura',
+                'diners'
+            ];
+        }
+    }
+
+    /**
+     * @When select the allowed credit cards
+     */
+    public function selectTheAllowedCreditCards()
+    {
+        $page = $this->getSession()->getPage();
+
+        $this->getSession()->wait(5000);
+        $select = $page->find(
+            'css',
+            '#payment_pagarme_settings_allowed_credit_card_brands'
+        );
+
+        $multiple = false;
+
+        foreach ($this->creditCardListToAllow as $creditCardValue) {
+            $select->selectOption($creditCardValue, $multiple);
+
+            if ($multiple === false) {
+                $multiple = true;
+            }
+        }
+    }
+
+    /**
+     * @Then the credit card list must be saved in database
+     */
+    public function theCreditCardListMustBeSavedInDatabase()
+    {
+        $this->flushCachedStoreConfig();
+
+        $creditCardsSavedAsString = \Mage::getStoreConfig(
+            'payment/pagarme_settings/allowed_credit_card_brands'
+        );
+
+        $creditCardsSavedAsArray = explode(',', $creditCardsSavedAsString);
+
+        \PHPUnit_Framework_TestCase::assertEquals(
+            sort($this->creditCardListToAllow),
+            sort($creditCardsSavedAsArray)
+        );
+    }
+
+    private function flushCachedStoreConfig()
+    {
+        Mage::app()->getStore()->resetConfig();
+    }
 
     /**
      * @AfterScenario

--- a/tests/acceptance/features/configure.feature
+++ b/tests/acceptance/features/configure.feature
@@ -21,3 +21,13 @@ Feature: Configuration Form
         And enable Pagar.me Checkout
         And save configuration
         Then Pagar.me checkout must be enabled
+
+    Scenario: Setting up allowed credit card brands
+        Given a admin user
+        And a credit card list to allow
+        When I access the admin
+        And go to system configuration page
+        And select the allowed credit cards
+        And save configuration
+        Then the configuration must be saved with success
+        And the credit card list must be saved in database


### PR DESCRIPTION
### Descrição

Adiciona multiselect para o administrador da loja selecionar os cartões de créditos permitidos para o checkout Pagar.me.

### Número da Issue

#117

### Testes Realizados

Teste e2e com Behat.

@devdrops @xduh @ricardotulio 
