### PR TITLE
Retornar apenas os cartões de crédito permitidos para as configurações do checkout Pagar.me

### DIFF
--- a/app/code/community/PagarMe/Checkout/Block/Form/Checkout.php
+++ b/app/code/community/PagarMe/Checkout/Block/Form/Checkout.php
@@ -108,6 +108,10 @@ class PagarMe_Checkout_Block_Form_Checkout extends Mage_Payment_Block_Form
 
         $telephone = $address->getTelephone();
 
+        $cardBrands = \Mage::getStoreConfig(
+            'payment/pagarme_settings/allowed_credit_card_brands'
+        );
+
         return json_encode([
             'amount' => $helper->parseAmountToInteger($quote->getGrandTotal()),
             'createToken' => 'true',
@@ -123,7 +127,8 @@ class PagarMe_Checkout_Block_Form_Checkout extends Mage_Payment_Block_Form
             'customerAddressComplementary' => $address->getStreet(3),
             'customerAddressNeighborhood' => $address->getStreet(4),
             'customerAddressCity' => $address->getCity(),
-            'customerAddressState' => $address->getRegion()
+            'customerAddressState' => $address->getRegion(),
+            'brands' => $cardBrands
         ]);
     }
 }

--- a/tests/unit/app/code/community/PagarMe/Checkout/Block/Form/CheckoutTest.php
+++ b/tests/unit/app/code/community/PagarMe/Checkout/Block/Form/CheckoutTest.php
@@ -2,6 +2,8 @@
 
 class PagarMe_Checkout_Block_Form_CheckoutTest extends PHPUnit_Framework_TestCase
 {
+    private $brands = 'mastercard,visa,elo,aura';
+
     /**
      * @test
      */
@@ -22,7 +24,8 @@ class PagarMe_Checkout_Block_Form_CheckoutTest extends PHPUnit_Framework_TestCas
             'customerAddressComplementary' => '',
             'customerAddressNeighborhood' => 'Downtown',
             'customerAddressCity' => 'Nowhere',
-            'customerAddressState' => 'XP'
+            'customerAddressState' => 'XP',
+            'brands' => $this->brands
         ];
 
         $quote = Mage::getModel('sales/quote')
@@ -51,6 +54,11 @@ class PagarMe_Checkout_Block_Form_CheckoutTest extends PHPUnit_Framework_TestCas
             ->setIsDefaultShipping(true)
             ->setSaveInAddressBook(true)
             ->save();
+
+        \Mage::app()->getStore()->setConfig(
+            'payment/pagarme_settings/allowed_credit_card_brands',
+            $this->brands
+        );
 
         $customer = Mage::getModel('customer/customer')
             ->load($customer->getId());


### PR DESCRIPTION
### Descrição

Retornar apenas os cartões de crédito permitidos para as configurações do checkout Pagar.me.

### Número da Issue

#119 

### Testes Realizados

Alteração no teste unitário já existente que verificava as configurações retornadas para o checkout Pagar.me.

@devdrops @xduh @ricardotulio 