### PR TITLE
Fix how to load api key

### DIFF
--- a/tests/acceptance/PostbackContext.php
+++ b/tests/acceptance/PostbackContext.php
@@ -28,7 +28,11 @@ class PostbackContext extends MinkContext
         $this->product = $this->getProduct();
         $this->product->save();
 
-        $this->apiKey = PAGARME_API_KEY;
+        \Mage::getConfig()
+            ->saveConfig('payment/pagarme_settings/api_key', PAGARME_API_KEY);
+
+        \Mage::getConfig()
+            ->saveConfig('payment/pagarme_settings/encryption_key', PAGARME_ENCRYPTION_KEY);
 
         $this->enablePagarmeCheckout();
     }
@@ -79,7 +83,9 @@ class PostbackContext extends MinkContext
 
         $payload = "id={$transactionId}&current_status={$currentStatus}";
 
-        $hash = hash_hmac($algorithm, $payload, $this->apiKey);
+        $apiKey = \Mage::getStoreConfig('payment/pagarme_settings/api_key');
+
+        $hash = hash_hmac($algorithm, $payload, $apiKey);
 
         $signature = "{$algorithm}={$hash}";
 


### PR DESCRIPTION
### Descrição

Altera a forma como o teste e2e de postback carrega a api key e encryption key. Desta forma, esse teste deixa de depender de outros testes e pode ser executado de forma isolada.

### Número da Issue

Issue #123 

### Testes Realizados

O teste de comportamento implementado para postback já cobre este caso.
