### PR TITLE
Fix/config path checkout switch

### DIFF
--- a/tests/acceptance/Helper/PagarMeCheckoutSwitch.php
+++ b/tests/acceptance/Helper/PagarMeCheckoutSwitch.php
@@ -16,8 +16,16 @@ trait PagarMeCheckoutSwitch
 
     protected function changePagarmeCheckout($value)
     {
-        $nodePath = "payment/pagarme_checkout/active";
-        \Mage::getConfig()->saveConfig($nodePath, $value);
+        \Mage::getConfig()->saveConfig(
+            'payment/pagarme_settings/active',
+            $value
+        );
+
+        \Mage::getConfig()->saveConfig(
+            'payment/pagarme_checkout/active',
+            $value
+        );
+
         \Mage::getConfig()->cleanCache();
     }
 }

--- a/tests/acceptance/PostbackContext.php
+++ b/tests/acceptance/PostbackContext.php
@@ -28,11 +28,7 @@ class PostbackContext extends MinkContext
         $this->product = $this->getProduct();
         $this->product->save();
 
-        \Mage::getConfig()
-            ->saveConfig('payment/pagarme_settings/api_key', PAGARME_API_KEY);
-
-        \Mage::getConfig()
-            ->saveConfig('payment/pagarme_settings/encryption_key', PAGARME_ENCRYPTION_KEY);
+        $this->apiKey = PAGARME_API_KEY;
 
         $this->enablePagarmeCheckout();
     }
@@ -83,9 +79,7 @@ class PostbackContext extends MinkContext
 
         $payload = "id={$transactionId}&current_status={$currentStatus}";
 
-        $apiKey = \Mage::getStoreConfig('payment/pagarme_settings/api_key');
-
-        $hash = hash_hmac($algorithm, $payload, $apiKey);
+        $hash = hash_hmac($algorithm, $payload, $this->apiKey);
 
         $signature = "{$algorithm}={$hash}";
 

--- a/tests/acceptance/PostbackContext.php
+++ b/tests/acceptance/PostbackContext.php
@@ -28,7 +28,11 @@ class PostbackContext extends MinkContext
         $this->product = $this->getProduct();
         $this->product->save();
 
-        $this->apiKey = PAGARME_API_KEY;
+        \Mage::getConfig()
+            ->saveConfig('payment/pagarme_settings/api_key', PAGARME_API_KEY);
+
+        \Mage::getConfig()
+            ->saveConfig('payment/pagarme_settings/encryption_key', PAGARME_ENCRYPTION_KEY);
 
         $this->enablePagarmeCheckout();
     }
@@ -79,7 +83,9 @@ class PostbackContext extends MinkContext
 
         $payload = "id={$transactionId}&current_status={$currentStatus}";
 
-        $hash = hash_hmac($algorithm, $payload, $this->apiKey);
+        $apiKey = \Mage::getStoreConfig('payment/pagarme_settings/api_key');
+
+        $hash = hash_hmac($algorithm, $payload, $apiKey);
 
         $signature = "{$algorithm}={$hash}";
 


### PR DESCRIPTION
### Descrição

Adiciona a ativação e desativação do módulo `pagarme_core` no método `PagarMe\Magento\Test\Helper\PagarMeCheckoutSwitch::changePagarmeCheckout()` para que o teste e2e de postback possa ser executado de forma independente.

### Número da Issue

#130 

### Testes Realizados

Executei o comando `$ docker-compose exec magento vendor/bin/behat -s postback` para testar o teste.
