### PR TITLE
Checkout Pagar.me - Salvar informações de Juros

### DIFF
--- a/app/code/community/PagarMe/Checkout/Block/Form/Checkout.php
+++ b/app/code/community/PagarMe/Checkout/Block/Form/Checkout.php
@@ -123,7 +123,13 @@ class PagarMe_Checkout_Block_Form_Checkout extends Mage_Payment_Block_Form
             'customerAddressComplementary' => $address->getStreet(3),
             'customerAddressNeighborhood' => $address->getStreet(4),
             'customerAddressCity' => $address->getCity(),
-            'customerAddressState' => $address->getRegion()
+            'customerAddressState' => $address->getRegion(),
+            'interestRate' => Mage::getStoreConfig(
+                'payment/pagarme_settings/interest_rate'
+            ),
+            'freeInstallments' => Mage::getStoreConfig(
+                'payment/pagarme_settings/free_installments'
+            )
         ]);
     }
 }

--- a/app/code/community/PagarMe/Checkout/Model/Checkout.php
+++ b/app/code/community/PagarMe/Checkout/Model/Checkout.php
@@ -163,7 +163,10 @@ class PagarMe_Checkout_Model_Checkout extends Mage_Payment_Model_Method_Abstract
             ->setInterestRate(
                 $infoInstance->getAdditionalInformation('interest_rate')
             )
-            ->setFutureValue(null)
+            ->setFutureValue(
+                Mage::helper('pagarme_core')
+                    ->parseAmountToFloat($transaction->getAmount())
+            )
             ->save();
     }
 }

--- a/app/code/community/PagarMe/Checkout/Model/Checkout.php
+++ b/app/code/community/PagarMe/Checkout/Model/Checkout.php
@@ -148,6 +148,8 @@ class PagarMe_Checkout_Model_Checkout extends Mage_Payment_Model_Method_Abstract
      * @param Mage_Sales_Model_Order_Payment $infoInstance
      *
      * @return void
+     *
+     * @codeCoverageIgnore
      */
     private function saveTransactionInformation(
         Mage_Sales_Model_Order $order,

--- a/app/code/community/PagarMe/Core/Helper/Data.php
+++ b/app/code/community/PagarMe/Core/Helper/Data.php
@@ -14,21 +14,36 @@ class PagarMe_Core_Helper_Data extends Mage_Core_Helper_Abstract
     public function prepareCustomerData($data)
     {
         return (object) [
-            'document_number' => Zend_Filter::filterStatic($data['pagarme_checkout_customer_document_number'], 'Digits'),
-            'document_type'   => $data['pagarme_checkout_customer_document_type'],
-            'name'            => $data['pagarme_checkout_customer_name'],
-            'email'           => $data['pagarme_checkout_customer_email'],
-            'born_at'         => $data['pagarme_checkout_customer_born_at'],
-            'addresses'       => [
+            'document_number' => Zend_Filter::filterStatic(
+                $data['pagarme_checkout_customer_document_number'],
+                'Digits'
+            ),
+            'document_type' => $data['pagarme_checkout_customer_document_type'],
+            'name' => $data['pagarme_checkout_customer_name'],
+            'email' => $data['pagarme_checkout_customer_email'],
+            'born_at' => $data['pagarme_checkout_customer_born_at'],
+            'addresses' => [
                 (object) [
-                    'street'        => $data['pagarme_checkout_customer_address_street_1'],
-                    'street_number' => $data['pagarme_checkout_customer_address_street_2'],
-                    'complementary' => $data['pagarme_checkout_customer_address_street_3'],
-                    'neighborhood'  => $data['pagarme_checkout_customer_address_street_4'],
-                    'city'          => $data['pagarme_checkout_customer_address_city'],
-                    'state'         => $data['pagarme_checkout_customer_address_state'],
-                    'zipcode'       => $data['pagarme_checkout_customer_address_zipcode'],
-                    'country'       => $data['pagarme_checkout_customer_address_country']
+                    'street' => $data[
+                        'pagarme_checkout_customer_address_street_1'
+                    ],
+                    'street_number' => $data[
+                        'pagarme_checkout_customer_address_street_2'
+                    ],
+                    'complementary' => $data[
+                        'pagarme_checkout_customer_address_street_3'
+                    ],
+                    'neighborhood' => $data[
+                        'pagarme_checkout_customer_address_street_4'
+                    ],
+                    'city' => $data['pagarme_checkout_customer_address_city'],
+                    'state' => $data['pagarme_checkout_customer_address_state'],
+                    'zipcode' => $data[
+                        'pagarme_checkout_customer_address_zipcode'
+                    ],
+                    'country' => $data[
+                        'pagarme_checkout_customer_address_country'
+                    ]
                 ]
             ],
             'phones'          => [
@@ -37,8 +52,8 @@ class PagarMe_Core_Helper_Data extends Mage_Core_Helper_Abstract
                     'number' => $data['pagarme_checkout_customer_phone_number'],
                 ],
             ],
-            'gender'          => $data['pagarme_checkout_customer_gender'],
-            'date_created'    => null
+            'gender' => $data['pagarme_checkout_customer_gender'],
+            'date_created' => null
         ];
     }
 
@@ -54,13 +69,23 @@ class PagarMe_Core_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * @param int $amount
+     * @param float $amount
      *
      * @return int
      */
     public function parseAmountToInteger($amount)
     {
         return intval($amount * 100);
+    }
+
+    /**
+     * @param int $amount
+     *
+     * @return float
+     */
+    public function parseAmountToFloat($amount)
+    {
+        return floatval($amount / 100);
     }
 
     /**

--- a/app/code/community/PagarMe/Core/etc/system.xml
+++ b/app/code/community/PagarMe/Core/etc/system.xml
@@ -71,6 +71,24 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </order_status_paid>
+                        <interest_rate translate="label">
+                            <label>Interest Rate (%)</label>
+                            <frontend_type>text</frontend_type>
+                            <frontend_class>validate-number</frontend_class>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </interest_rate>
+                        <free_installments translate="label">
+                            <label>Free Installments</label>
+                            <frontend_type>text</frontend_type>
+                            <frontend_class>validate-number</frontend_class>
+                            <sort_order>45</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </free_installments>
                     </fields>
                 </pagarme_settings>
             </groups>

--- a/app/design/frontend/base/default/template/pagarme/form/checkout.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/checkout.phtml
@@ -1,26 +1,32 @@
 <ul class="form-list" id="payment_form_pagarme_checkout" style="display:none;">
     <input type="hidden" value="" name="payment[pagarme_checkout_token]" id="pagarme_checkout_token" class="required_entry" />
     <input type="hidden" value="" name="payment[pagarme_checkout_payment_method]" id="pagarme_checkout_payment_method" />
+    <input type="hidden" value="" name="payment[pagarme_checkout_interest_rate]" id="pagarme_checkout_interest_rate" />
 
     <div style="display:none;" id="advice-required-entry-pagarme-checkout-hash" class="validation-advice">
         <?php echo __("Please click the button below<br />and complete the information."); ?>
     </div>
 
     <button id="pagarme-checkout-fill-info-button" class="button" type="button">
-        <span><span><?php echo __('Fill in the card data'); ?></span></span>
+        <span>
+            <span><?php echo __('Fill in the card data'); ?></span>
+        </span>
     </button>
 </ul>
 
 <script type="text/javascript" id="pagarme-checkout">
     $("pagarme-checkout-fill-info-button").observe("click", function (event){
+        var pagarmeCheckoutSettings = <?= $this->getCheckoutConfig() ?>;
+
         var checkoutPagarme = new PagarMeCheckout.Checkout({
             "encryption_key" : "<?= $this->getEncryptionKey() ?>",
             success: function (response) {
                 $('pagarme_checkout_token').value = response['token'];
                 $('pagarme_checkout_payment_method').value = response['payment_method'];
+                $('pagarme_checkout_interest_rate').value = pagarmeCheckoutSettings.interestRate;
             }
         });
 
-        checkoutPagarme.open(<?= $this->getCheckoutConfig() ?>);
+        checkoutPagarme.open(pagarmeCheckoutSettings);
     });
 </script>

--- a/tests/unit/app/code/community/PagarMe/Checkout/Block/Form/CheckoutTest.php
+++ b/tests/unit/app/code/community/PagarMe/Checkout/Block/Form/CheckoutTest.php
@@ -22,7 +22,9 @@ class PagarMe_Checkout_Block_Form_CheckoutTest extends PHPUnit_Framework_TestCas
             'customerAddressComplementary' => '',
             'customerAddressNeighborhood' => 'Downtown',
             'customerAddressCity' => 'Nowhere',
-            'customerAddressState' => 'XP'
+            'customerAddressState' => 'XP',
+            'interestRate' => Mage::getStoreConfig('payment/pagarme_settings/interest_rate'),
+            'freeInstallments' => Mage::getStoreConfig('payment/pagarme_settings/free_installments')
         ];
 
         $quote = Mage::getModel('sales/quote')

--- a/tests/unit/app/code/community/PagarMe/Core/Helper/DataTest.php
+++ b/tests/unit/app/code/community/PagarMe/Core/Helper/DataTest.php
@@ -61,4 +61,54 @@ class PagarMe_Core_Helper_DataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $this->helper->getPhoneWithoutDdd($phone));
     }
+
+    /**
+     * @test
+     *
+     * @dataProvider getFloatValues
+     */
+    public function mustParseFloatValuesToInteger($value)
+    {
+        $subject = $this->helper->parseAmountToInteger($value);
+
+        $this->assertInternalType('int', $subject);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getIntegerValues
+     */
+    public function mustParseIntegerValuesToToFloat($value)
+    {
+        $subject = $this->helper->parseAmountToFloat($value);
+
+        $this->assertInternalType('float', $subject);
+    }
+
+    /**
+     * @return array
+     */
+    public function getFloatValues()
+    {
+        return [
+            [123.45],
+            [1.1],
+            [0.8],
+            [12345678.90],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getIntegerValues()
+    {
+        return [
+            [12345],
+            [2],
+            [1],
+            [1234567890],
+        ];
+    }
 }


### PR DESCRIPTION
### Descrição

Salva no banco de dados do Magento as informações de juros da transação realizada (taxa de juros, número de parcelas e valor transacionado). 

### Número da Issue

#132 

### Testes Realizados

Adicionados testes unitários para os métodos de manipulação de valores numéricos da transação.