### PR TITLE
Removendo método desnecessário como observer do config.xml

### DIFF
--- a/app/code/community/Inovarti/Pagarme/etc/config.xml
+++ b/app/code/community/Inovarti/Pagarme/etc/config.xml
@@ -216,15 +216,6 @@
                     </inchoo_test_log_cart_add>
                 </observers>
             </sales_quote_add_item>
-            <controller_action_postdispatch_checkout_onepage_savePayment>
-                <observers>
-                    <pagarme>
-                        <type>singleton</type>
-                        <class>pagarme/observer</class>
-                        <method>addCreditCardInterestFee</method>
-                    </pagarme>
-                </observers>
-            </controller_action_postdispatch_checkout_onepage_savePayment>
             <controller_front_init_before>
                 <observers>
                     <add_pagarme_library>


### PR DESCRIPTION
### Descrição

Método `addCreditCardInterestFee` está configurado no arquivo `config.xml` do módulo, mas não há correspondente no *model Observer*. Conforme discussão interna, esse método está *deprecated* e não deveria estar no `config.xml`.

### Número da Issue

#134 