### PR TITLE
Checkout Pagar.me - Exibir informações de juros na tela de Order do Admin

### DIFF
--- a/app/code/community/PagarMe/Checkout/Block/Info/Checkout.php
+++ b/app/code/community/PagarMe/Checkout/Block/Info/Checkout.php
@@ -1,0 +1,31 @@
+<?php
+
+class PagarMe_Checkout_Block_Info_Checkout extends Mage_Payment_Block_Info
+{
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return void
+     */
+    public function _construct()
+    {
+        parent::_construct();
+
+        $this->setTemplate('pagarme/checkout/order_info/payment_details.phtml');
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return PagarMe_Core_Model_Transaction
+     */
+    public function getTransaction()
+    {
+        return \Mage::getModel('pagarme_core/service_order')
+            ->getTransactionByOrderId(
+                $this->getInfo()
+                    ->getOrder()
+                    ->getId()
+            );
+    }
+}

--- a/app/code/community/PagarMe/Checkout/Model/Checkout.php
+++ b/app/code/community/PagarMe/Checkout/Model/Checkout.php
@@ -34,6 +34,10 @@ class PagarMe_Checkout_Model_Checkout extends Mage_Payment_Model_Method_Abstract
      * @var string
      */
     protected $_formBlockType = 'pagarme_checkout/form_checkout';
+    /**
+     * @var string
+     */
+    protected $_infoBlockType = 'pagarme_checkout/info_checkout';
 
     const PAGARME_CHECKOUT_CREDIT_CARD = 'pagarme_checkout_credit_card';
     const PAGARME_CHECKOUT_BOLETO = 'pagarme_checkout_boleto';

--- a/app/code/community/PagarMe/Checkout/etc/config.xml
+++ b/app/code/community/PagarMe/Checkout/etc/config.xml
@@ -22,6 +22,15 @@
             </pagarme_checkout>
         </blocks>
     </global>
+    <adminhtml>
+        <layout>
+            <updates>
+                <pagarme_checkout>
+                    <file>pagarme/pagarme_checkout.xml</file>
+                </pagarme_checkout>
+            </updates>
+        </layout>
+    </adminhtml>
     <frontend>
         <layout>
             <updates>

--- a/app/code/community/PagarMe/Core/Model/Service/Order.php
+++ b/app/code/community/PagarMe/Core/Model/Service/Order.php
@@ -23,7 +23,7 @@ class PagarMe_Core_Model_Service_Order
     /**
      * @codeCoverageIgnore
      *
-     * @param Mage_Sales_Model_Order
+     * @param Mage_Sales_Model_Order $order
      *
      * @return int $transactionId
      */
@@ -32,5 +32,18 @@ class PagarMe_Core_Model_Service_Order
         return Mage::getModel('pagarme_core/transaction')
             ->load($order->getId(), 'order_id')
             ->getTransactionId();
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @param int $orderId
+     *
+     * @return PagarMe_Core_Model_Transaction
+     */
+    public function getTransactionByOrderId($orderId)
+    {
+        return Mage::getModel('pagarme_core/transaction')
+            ->load($orderId, 'order_id');
     }
 }

--- a/app/code/community/PagarMe/Core/sql/pagarme_core_setup/mysql4-install-2.0.0.php
+++ b/app/code/community/PagarMe/Core/sql/pagarme_core_setup/mysql4-install-2.0.0.php
@@ -42,6 +42,11 @@ $table = $installer->getConnection()
         'future_value',
         Varien_Db_Ddl_Table::TYPE_FLOAT,
         null
+    )
+    ->addColumn(
+        'rate_amount',
+        Varien_Db_Ddl_Table::TYPE_FLOAT,
+        null
     );
 
 $installer->getConnection()

--- a/app/design/adminhtml/default/default/layout/pagarme/pagarme_checkout.xml
+++ b/app/design/adminhtml/default/default/layout/pagarme/pagarme_checkout.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<layout>
+    <default>
+        <reference name="head">
+            <block type="core/text" name="pagarme.cdn.js.checkout" ifconfig="payment/pagarme_settings/active">
+                <action method="setText">
+                    <text><![CDATA[<script src="https://assets.pagar.me/checkout/checkout.js" type="text/javascript"></script>]]></text>
+                </action>
+        	</block>
+        </reference>
+    </default>
+    <checkout_onepage_success>
+        <reference name="content">
+            <block type="pagarme_checkout/success" name="pagarme_checkout.success" template="pagarme/success.phtml"/>
+        </reference>
+    </checkout_onepage_success>
+    <adminhtml_sales_order_view>
+        <reference name="order_totals">
+            <block name="pagarme_checkout_rate_amount" type="adminhtml/sales_order_totals_item" template="pagarme/checkout/interest_rate/rate_amount.phtml"/>
+        </reference>
+    </adminhtml_sales_order_view>
+</layout>

--- a/app/design/adminhtml/default/default/template/pagarme/checkout/interest_rate/rate_amount.phtml
+++ b/app/design/adminhtml/default/default/template/pagarme/checkout/interest_rate/rate_amount.phtml
@@ -3,7 +3,7 @@
 ?>
 
 <?php if ($transaction->getRateAmount() > 0): ?>
-    <tr>
+    <tr id="pagarme_order_info_rate_amount">
         <td class="label">Rate Amount</td>
         <td><?= $this->displayPrices($transaction->getRateAmount(), $transaction->getRateAmount()) ?></td>
     </tr>

--- a/app/design/adminhtml/default/default/template/pagarme/checkout/interest_rate/rate_amount.phtml
+++ b/app/design/adminhtml/default/default/template/pagarme/checkout/interest_rate/rate_amount.phtml
@@ -1,0 +1,10 @@
+<?php
+    $transaction = \Mage::getModel('pagarme_core/service_order')->getTransactionByOrderId($this->getOrder()->getId());
+?>
+
+<?php if ($transaction->getRateAmount() > 0): ?>
+    <tr>
+        <td class="label">Rate Amount</td>
+        <td><?= $this->displayPrices($transaction->getRateAmount(), $transaction->getRateAmount()) ?></td>
+    </tr>
+<?php endif; ?>

--- a/app/design/adminhtml/default/default/template/pagarme/checkout/order_info/payment_details.phtml
+++ b/app/design/adminhtml/default/default/template/pagarme/checkout/order_info/payment_details.phtml
@@ -1,0 +1,44 @@
+<?php $transaction = $this->getTransaction(); ?>
+
+<h3>Checkout Pagar.me</h3>
+
+<table>
+    <tr>
+        <td>
+            <strong>Payment Method</strong>
+        </td>
+        <td>
+           <?= ($transaction->getInstallments() > 0) ? 'Cartão de Crédito' : 'Boleto' ?>
+        </td>
+    </tr>
+    <?php if ($transaction->getInstallments() > 0): ?>
+        <tr>
+            <td>
+                <strong>Installments</strong>
+            </td>
+            <td style="text-align:right;">
+               <?= $transaction->getInstallments() ?>
+            </td>
+        </tr>
+    <?php endif; ?>
+    <?php if ($transaction->getInterestRate() > 0): ?>
+        <tr>
+            <td>
+                <strong>Interest Fee (%)</strong>
+            </td>
+            <td style="text-align:right;">
+               <?= $transaction->getInterestRate() ?>
+            </td>
+        </tr>
+    <?php endif; ?>
+    <tr>
+        <td>
+            <strong>Transaction Id</strong>
+        </td>
+        <td style="text-align:right;">
+           <?= $transaction->getTransactionId() ?>
+        </td>
+    </tr>
+</table>
+
+<br/>

--- a/app/design/adminhtml/default/default/template/pagarme/checkout/order_info/payment_details.phtml
+++ b/app/design/adminhtml/default/default/template/pagarme/checkout/order_info/payment_details.phtml
@@ -2,7 +2,7 @@
 
 <h3>Checkout Pagar.me</h3>
 
-<table>
+<table id="pagarme_order_info_payment_details">
     <tr>
         <td>
             <strong>Payment Method</strong>

--- a/behat.yml
+++ b/behat.yml
@@ -30,3 +30,10 @@ default:
         - %paths.base%/tests/acceptance/features/payment_method_availability.feature
       contexts:
         - PaymentMethodAvailabilityContext
+    order_view:
+      paths:
+        - %paths.base%/tests/acceptance/features/order_view.feature
+      contexts:
+        - OrderViewContext
+        - CheckoutContext
+        - ConfigureContext

--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -255,7 +255,7 @@ class CheckoutContext extends MinkContext
      */
     public function thePurchaseMustBePaidWithSuccess()
     {
-        $this->session->wait(5000);
+        $this->session->wait(8000);
 
         $page = $this->session->getPage();
 

--- a/tests/acceptance/ConfigureContext.php
+++ b/tests/acceptance/ConfigureContext.php
@@ -1,12 +1,12 @@
 <?php
 
 use Behat\Behat\Tester\Exception\PendingException;
-use Behat\MinkExtension\Context\MinkContext;
+use Behat\MinkExtension\Context\RawMinkContext;
 
 require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-class ConfigureContext extends MinkContext
+class ConfigureContext extends RawMinkContext
 {
     use PagarMe\Magento\Test\Helper\CustomerDataProvider;
     use PagarMe\Magento\Test\Helper\ProductDataProvider;

--- a/tests/acceptance/ConfigureContext.php
+++ b/tests/acceptance/ConfigureContext.php
@@ -41,6 +41,7 @@ class ConfigureContext extends RawMinkContext
 
     /**
      * @Given a admin user
+     * @Then as an Admin user
      */
     public function aAdminUser()
     {
@@ -238,7 +239,6 @@ class ConfigureContext extends RawMinkContext
             Mage::helper('core')->isModuleEnabled('PagarMe_Core')
         );
     }
-
 
     /**
      * @AfterScenario

--- a/tests/acceptance/OrderViewContext.php
+++ b/tests/acceptance/OrderViewContext.php
@@ -7,5 +7,78 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 class OrderViewContext extends RawMinkContext
 {
+    const PAYMENT_METHOD_CREDIT_CARD_LABEL = 'Cartão de crédito';
+    const PAYMENT_METHOD_BOLETO_LABEL = 'Boleto';
     
+    /**
+     * @When navigate to the Order page
+     */
+    public function andNavigateToTheOrderPage()
+    {
+        $session = $this->getSession();
+        $page = $session->getPage();
+
+        $popup = $page->find('css', '.message-popup-head a');
+
+        if ($popup instanceof \Behat\Mink\Element\NodeElement) {
+            $popup->click();
+        }
+
+        $page->find('named', array('link', 'Sales'))
+            ->mouseOver();
+
+        $page->find('named', array('link', 'Orders'))
+            ->click();
+    }
+
+    /**
+     * @When click on the last created Order
+     */
+    public function andClickOnTheLastCreatedOrder()
+    {
+        $session = $this->getSession();
+        $page = $session->getPage();
+
+        $page->find('css', '#sales_order_grid_table tbody tr td a')->click();
+    }
+
+    /**
+     * @Then I see that the interest rate information for :paymentMethod is present
+     */
+    public function thenISeeThatTheInterestRateValueIsPresent($paymentMethod)
+    {
+        $session = $this->getSession();
+        $page = $session->getPage();
+
+        $element = $page->find('css', '#pagarme_order_info_payment_details');
+
+        \PHPUnit_Framework_TestCase::assertInstanceOf(
+            'Behat\Mink\Element\NodeElement',
+            $element
+        );
+
+        $htmlContent = $element->getHtml();
+
+        if ($paymentMethod === self::PAYMENT_METHOD_CREDIT_CARD_LABEL) {
+            \PHPUnit_Framework_TestCase::assertContains(
+                'Installments',
+                $htmlContent
+            );
+        }
+
+        \PHPUnit_Framework_TestCase::assertContains(
+            $paymentMethod,
+            $htmlContent
+        );
+
+        \PHPUnit_Framework_TestCase::assertContains(
+            'Interest Fee',
+            $htmlContent
+        );
+
+        \PHPUnit_Framework_TestCase::assertContains(
+            'Transaction Id',
+            $htmlContent
+        );
+    }
 }

--- a/tests/acceptance/OrderViewContext.php
+++ b/tests/acceptance/OrderViewContext.php
@@ -1,0 +1,11 @@
+<?php
+
+use Behat\MinkExtension\Context\RawMinkContext;
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+class OrderViewContext extends RawMinkContext
+{
+    
+}

--- a/tests/acceptance/features/order_view.feature
+++ b/tests/acceptance/features/order_view.feature
@@ -8,25 +8,26 @@ Feature: Order Visualization
         When I access the store page
         And add any product to basket
         And I go to checkout page
-        And login with registered user
+        When login with registered user
         And confirm billing and shipping address information
         And choose pay with pagar me checkout using "Cartão de crédito"
         And I confirm my personal data
+        Given a valid credit card
+        And I confirm my payment information
         And finish purchase
         Then the purchase must be paid with success
         Then as an Admin user
         When I access the admin
         And navigate to the Order page
         And click on the last created Order
-        Then I see that the interest rate value is present
-        And I see the payment information is displayed as well
+        Then I see that the interest rate information for "Cartão de Crédito" is present
 
     Scenario: Order Rate Value and Info from Boleto Purchase
         Given a registered user
         When I access the store page
         And add any product to basket
         And I go to checkout page
-        And login with registered user
+        When login with registered user
         And confirm billing and shipping address information
         And choose pay with pagar me checkout using "Boleto"
         And I confirm my personal data
@@ -36,5 +37,4 @@ Feature: Order Visualization
         When I access the admin
         And navigate to the Order page
         And click on the last created Order
-        Then I see that the interest rate value is present
-        And I see the payment information is displayed as well
+        Then I see that the interest rate information for "Boleto" is present

--- a/tests/acceptance/features/order_view.feature
+++ b/tests/acceptance/features/order_view.feature
@@ -1,0 +1,40 @@
+Feature: Order Visualization
+    As an administrator of a webstore
+    I want to visualize the Pagar.me transaction information
+    So then I can check all the information on my transactions
+
+    Scenario: Order Rate Value and Info from Credit Card Purchase
+        Given a registered user
+        When I access the store page
+        And add any product to basket
+        And I go to checkout page
+        And login with registered user
+        And confirm billing and shipping address information
+        And choose pay with pagar me checkout using "Cartão de crédito"
+        And I confirm my personal data
+        And finish purchase
+        Then the purchase must be paid with success
+        Then as an Admin user
+        When I access the admin
+        And navigate to the Order page
+        And click on the last created Order
+        Then I see that the interest rate value is present
+        And I see the payment information is displayed as well
+
+    Scenario: Order Rate Value and Info from Boleto Purchase
+        Given a registered user
+        When I access the store page
+        And add any product to basket
+        And I go to checkout page
+        And login with registered user
+        And confirm billing and shipping address information
+        And choose pay with pagar me checkout using "Boleto"
+        And I confirm my personal data
+        And finish purchase
+        Then the purchase must be paid with success
+        Then as an Admin user
+        When I access the admin
+        And navigate to the Order page
+        And click on the last created Order
+        Then I see that the interest rate value is present
+        And I see the payment information is displayed as well


### PR DESCRIPTION
### Descrição

Exibir as informações de juros de cada transação nas Orders do Magento.

### Número da Issue

#120

### Testes Realizados

- Execuções manuais
- Adição de testes de aceitação para validar a presença da informação de juros, tanto para cartão de crédito como para boleto.
