### PR TITLE
Aumentar mlisegundos de espera em teste do behat

### DIFF
--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -269,7 +269,7 @@ class CheckoutContext extends RawMinkContext
         $this->session->switchToIframe();
 
         $this->session->wait(
-            5000,
+            10000,
             "document.querySelector('#pagarme-checkout-container').style.display == 'none'"
         );
 


### PR DESCRIPTION
### Descrição

Espera mais tempo pela resposta do modal de checkout antes de clicar no
botão `continue` da página de checkout.

Esse aumento é para quando a API demorar para responder, o que estava
causando alguns erros durante a execução dos testes testes do behat.

Conforme a documentação do mink, essa espera só ocorrerá quando o
javascript não tiver respondido antes.

[ci-skip]