### PR TITLE
Corrigindo quebra de outros meios de pagamento após instalar módulo Pagar.me

### DIFF
--- a/app/code/community/PagarMe/Checkout/Model/Total.php
+++ b/app/code/community/PagarMe/Checkout/Model/Total.php
@@ -34,6 +34,15 @@ class PagarMe_Checkout_Model_Total
             return $this;
         }
 
+        $paymentMethod = $address->getQuote()
+            ->getPayment()
+            ->getMethodInstance()
+            ->getCode();
+
+        if ($paymentMethod != $this->getCode()) {
+            return $this;
+        }
+
         if ($this->interestAmount != 0) {
             return $this;
         }

--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -366,6 +366,34 @@ class CheckoutContext extends RawMinkContext
     }
 
     /**
+     * @When choose pay with checkmo
+     */
+    public function choosePayWithCheckmo()
+    {
+        $this->session->getPage()->find('css', '#p_method_checkmo')->click();
+
+        $this->session->getPage()->find(
+            'css',
+            '#payment-buttons-container button'
+        )->press();
+
+        $this->waitForElement('#checkout-step-review', 5000);
+    }
+
+    /**
+     * @Then I must be able to finish the payment process
+     */
+    public function iMustBeAbleToFinishThePaymentProcess()
+    {
+        $isPlaceOrderButtonVisible = $this->session->getPage()->find(
+            'css',
+            '.btn-checkout'
+        )->isVisible();
+
+        \PHPUnit_Framework_TestCase::assertTrue($isPlaceOrderButtonVisible);
+    }
+
+    /**
      * @AfterScenario
      */
     public function tearDown()

--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -159,13 +159,6 @@ class CheckoutContext extends RawMinkContext
             ->press();
 
         $this->waitForElement('#checkout-step-payment', 5000);
-
-        $page->find('css', '#p_method_pagarme_checkout')->click();
-        $page->pressButton(
-            Mage::getStoreConfig(
-                'payment/pagarme_settings/button_text'
-            )
-        );
     }
 
      /**
@@ -174,6 +167,13 @@ class CheckoutContext extends RawMinkContext
     public function choosePayWithPagarMeCheckoutUsing($paymentMethod)
     {
         $page = $this->session->getPage();
+
+        $page->find('css', '#p_method_pagarme_checkout')->click();
+        $page->pressButton(
+            Mage::getStoreConfig(
+                'payment/pagarme_settings/button_text'
+            )
+        );
 
         $this->session->switchToIframe(
             $page->find('css', 'iframe')->getAttribute('name')

--- a/tests/acceptance/features/checkout.feature
+++ b/tests/acceptance/features/checkout.feature
@@ -46,3 +46,13 @@ Feature: Checkout Pagar.me
         And finish payment process
         Then the interest must applied
         And the interest must be described in checkout
+
+    Scenario: Select a different payment method to ensure that it is working
+        Given a registered user
+        When I access the store page
+        And add any product to basket
+        And I go to checkout page
+        And login with registered user
+        And confirm billing and shipping address information
+        And choose pay with checkmo
+        Then I must be able to finish the payment process


### PR DESCRIPTION
### Descrição

Após instalar o módulo pagar.me, outros métodos de pagamento estavam quebrando.

### Número da Issue

#154 

### Testes Realizados

Testes de comportamento utilizando behat.
