### PR TITLE
Removendo chamada para Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,7 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  - wget https://github.com/satooshi/php-coveralls/releases/download/${COVERALLS_VERSION}/coveralls.phar
   - echo "MAGENTO_VERSION=$MAGENTO_VERSION" >> .env
 
 script:
   - script/test.sh
-
-after_success:
-  - travis_retry php coveralls.phar


### PR DESCRIPTION
### Descrição

Removendo chamada para coveralls da execução no Travis.

Erro encontrado ao executar o step do Coveralls:
![screenshot from 2017-04-20 17-44-57](https://cloud.githubusercontent.com/assets/1259313/25251889/578ca9ea-25f1-11e7-8405-7268cc4e5ce9.png)
