### PR TITLE
Correção para Exceção de Cliente Já Cadastrado

### DIFF
--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -496,8 +496,11 @@ class CheckoutContext extends RawMinkContext
      */
     public function tearDown()
     {
-        $this->customer->delete();
+        $customer = \Mage::getModel('customer/customer')
+            ->load($this->customer->getId());
+        $customer->delete();
         $this->product->delete();
+
         $this->restorePagarMeSettings();
     }
 }

--- a/tests/acceptance/ConfigureContext.php
+++ b/tests/acceptance/ConfigureContext.php
@@ -483,7 +483,9 @@ class ConfigureContext extends RawMinkContext
     public function tearDown()
     {
         $this->adminUser->delete();
-        $this->customer->delete();
+        $customer = \Mage::getModel('customer/customer')
+            ->load($this->customer->getId());
+        $customer->delete();
         $this->product->delete();
         $this->restorePagarMeSettings();
     }

--- a/tests/acceptance/Helper/PagarMeSettings.php
+++ b/tests/acceptance/Helper/PagarMeSettings.php
@@ -30,7 +30,8 @@ trait PagarMeSettings
             'credit_card_helper_text' => '',
             'ui_color' => '',
             'header_text' => '',
-            'checkout_button_text' => ''
+            'checkout_button_text' => '',
+            'payment_action' => 'authorize_capture'
         ];
     }
 }

--- a/tests/acceptance/OrderViewContext.php
+++ b/tests/acceptance/OrderViewContext.php
@@ -266,7 +266,9 @@ class OrderViewContext extends RawMinkContext
      */
     public function tearDown()
     {
-        $this->customer->delete();
+        $customer = \Mage::getModel('customer/customer')
+            ->load($this->customer->getId());
+        $customer->delete();
         $this->product->delete();
         $this->restorePagarMeSettings();
     }


### PR DESCRIPTION
### Descrição

Corrige o problema de Customer cadastrado com o mesmo email.

```
  ┌─ @BeforeScenario # OrderViewContext::setUp()
  │
  ╳  This customer email already exists (Mage_Customer_Exception)
  │
```

### Testes Realizados

Execução dos testes de aceitação, modificando o comportamento do Customer para ter o email estático (alteração feita somente para testes, sendo removida deste PR).