### PR TITLE
Adiciona bandeira discovery

### DIFF
--- a/app/code/community/PagarMe/Core/Model/System/Config/Source/CreditCardBrands.php
+++ b/app/code/community/PagarMe/Core/Model/System/Config/Source/CreditCardBrands.php
@@ -42,6 +42,10 @@ class PagarMe_Core_Model_System_Config_Source_CreditCardBrands
                 'value' => 'elo',
                 'label' => 'Elo'
             ],
+            [
+                'value' => 'discover',
+                'label' => 'Discover'
+            ],
         ];
     }
 }


### PR DESCRIPTION
### Descrição

Adiciona bandeira `discovery` a lista de cartões aceitos

### Testes Realizados

Teste manual