### PR TITLE
Personalizar o titulo do meio de pagamento

### DIFF
--- a/app/code/community/PagarMe/Checkout/Model/Checkout.php
+++ b/app/code/community/PagarMe/Checkout/Model/Checkout.php
@@ -59,6 +59,18 @@ class PagarMe_Checkout_Model_Checkout extends Mage_Payment_Model_Method_Abstract
     }
 
     /**
+     * Retrieve payment method title
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return Mage::getStoreConfig(
+            'payment/pagarme_settings/title'
+        );
+    }
+
+    /**
      * @param array $data
      *
      * @return $this

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -94,12 +94,12 @@
                 <active>0</active>
                 <model>pagarme_checkout/checkout</model>
                 <order_status>pending</order_status>
-                <title>Pagarme Checkout</title>
                 <allowspecific>0</allowspecific>
                 <payment_methods>credit_card,boleto</payment_methods>
                 <payment_action>authorize</payment_action>
             </pagarme_checkout>
             <pagarme_settings>
+                <title>Pagarme Checkout</title>
                 <button_text>Realizar pagamento</button_text>
                 <interest_rate>0</interest_rate>
                 <free_installments>1</free_installments>

--- a/app/code/community/PagarMe/Core/etc/system.xml
+++ b/app/code/community/PagarMe/Core/etc/system.xml
@@ -144,6 +144,14 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                         </heading_visual_config>
+                        <title translate="label">
+                            <label>Payment method title</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>301</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </title>
                         <payment_button_text translate="label">
                             <label>Checkout final button text</label>
                             <frontend_type>text</frontend_type>

--- a/app/locale/pt_BR/PagarMe_Core.csv
+++ b/app/locale/pt_BR/PagarMe_Core.csv
@@ -22,3 +22,4 @@
 "Credit Card Configurations", "Configurações de Cartão de Crédito"
 "Boleto Configurations", "Configurações de Boleto"
 "Visual Configurations", "Configurações Visuais"
+"Payment method title", "Título do meio de pagamento"

--- a/tests/acceptance/ConfigureContext.php
+++ b/tests/acceptance/ConfigureContext.php
@@ -328,6 +328,17 @@ class ConfigureContext extends RawMinkContext
     }
 
     /**
+     * @When change payment method title
+     */
+    public function changeThePaymentMethodTitle()
+    {
+        $this->getSession()->getPage()->fillField(
+            'payment_pagarme_settings_title',
+            'Meu meio de pagamento'
+        );
+    }
+
+    /**
      * @When I set max instalments to :maxInstallmets
      */
     public function iSetMaxInstalmentsTo($maxInstallmets)

--- a/tests/acceptance/Helper/PagarMeSettings.php
+++ b/tests/acceptance/Helper/PagarMeSettings.php
@@ -31,7 +31,8 @@ trait PagarMeSettings
             'ui_color' => '',
             'header_text' => '',
             'checkout_button_text' => '',
-            'payment_action' => 'authorize_capture'
+            'payment_action' => 'authorize_capture',
+            'title' => 'Pagar.me Checkout'
         ];
     }
 }

--- a/tests/acceptance/features/configure.feature
+++ b/tests/acceptance/features/configure.feature
@@ -40,6 +40,7 @@ Feature: Configuration Form
         And change the header text
         And change the payment button text
         And change the checkout button text
+        And change payment method title
         And save configuration
         Then the configuration must be saved with success
 


### PR DESCRIPTION
### Descrição

Permite alterar o titulo do meio de pagamento através do admin do magento

### Testes Realizados

Adicionado teste automatizado