### PR TITLE
Remover botão do checkout após a compra ser efetuada com sucesso

### DIFF
--- a/app/design/frontend/base/default/template/pagarme/form/checkout.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/checkout.phtml
@@ -17,7 +17,13 @@
 </ul>
 
 <script type="text/javascript" id="pagarme-checkout">
-    $("pagarme-checkout-fill-info-button").observe("click", function (event){
+    var checkoutButton = $('pagarme-checkout-fill-info-button')
+
+    if ($('pagarme_checkout_payment_method').value !== "") {
+      checkoutButton.remove();
+    }
+
+    checkoutButton && checkoutButton.observe("click", function (event){
         var pagarmeCheckoutSettings = <?= json_encode($this->getCheckoutConfig()) ?>;
 
         var checkoutPagarme = new PagarMeCheckout.Checkout({
@@ -26,6 +32,7 @@
                 $('pagarme_checkout_token').value = response['token'];
                 $('pagarme_checkout_payment_method').value = response['payment_method'];
                 $('pagarme_checkout_interest_rate').value = pagarmeCheckoutSettings.interestRate;
+                checkoutButton.remove();
 
                 if (typeof OSCPayment !== undefined) {
                     OSCPayment.savePayment();

--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -509,4 +509,20 @@ class CheckoutContext extends RawMinkContext
         $this->product->delete();
         $this->restorePagarMeSettings();
     }
+
+    /**
+     * @Then The button that opens pagarme checkout must be hidden
+     */
+    public function theButtonThatOpensPagarmeCheckoutMustBeHidden()
+    {
+        $checkoutButton = $this->getSession()->getPage()->find(
+            'css',
+            '#pagarme-checkout-fill-info-button'
+        );
+        \PHPUnit_Framework_TestCase::assertEquals(
+            $checkoutButton,
+            NULL
+        );
+    }
+
 }

--- a/tests/acceptance/OneStepCheckoutContext.php
+++ b/tests/acceptance/OneStepCheckoutContext.php
@@ -577,4 +577,20 @@ class OneStepCheckoutContext extends RawMinkContext
 
         $this->getSession()->wait(2000);
     }
+
+    /**
+     * @Then The button that opens pagarme checkout must be hidden
+     */
+    public function theButtonThatOpensPagarmeCheckoutMustBeHidden()
+    {
+        $checkoutButton = $this->getSession()->getPage()->find(
+            'css',
+            '#pagarme-checkout-fill-info-button'
+        );
+        \PHPUnit_Framework_TestCase::assertEquals(
+            $checkoutButton,
+            NULL
+        );
+    }
+
 }

--- a/tests/acceptance/features/checkout.feature
+++ b/tests/acceptance/features/checkout.feature
@@ -65,3 +65,18 @@ Feature: Checkout Pagar.me
         And finish payment process
         Then the interest must applied
         And the interest must be described in checkout
+
+    Scenario: Hide pagarme checkout button after success
+        Given a registered user
+        And a valid credit card
+        When I access the store page
+        And add any product to basket
+        And I go to checkout page
+        And login with registered user
+        And confirm billing and shipping address information
+        And choose pay with pagar me checkout using "Cartão de crédito"
+        And I confirm my personal data
+        And I confirm my payment information with "1" installments
+        And finish payment process
+        Then The button that opens pagarme checkout must be hidden
+

--- a/tests/acceptance/features/one_step_checkout.feature
+++ b/tests/acceptance/features/one_step_checkout.feature
@@ -106,3 +106,9 @@ Feature: One Step Checkout Pagar.me
         When I confirm payment using "5" installments
         And place order
         Then the purchase must be created with success
+
+    Scenario: Hide pagarme checkout button after success
+        Given I am on checkout page using Inovarti One Step Checkout
+        When I confirm payment
+        Then The button that opens pagarme checkout must be hidden
+


### PR DESCRIPTION
### Descrição

Esse PR desabilita o botao de continuar quando o ckeckout pagarme esta selecionado e ainda não foi pago. Após o pagamento ele retira o botão de abrir o checkout e habilita o botão de continuar.

Tem um problema nesse PR pq ele quebra o One Step Checkout. Isso acontece pois os Ids dos botões e a maneira com que ele carrega o script são diferentes. Precisamos de uma maneira de separar os scripts do checkout normal e do One Step para corrigir esse problema e os 2 funcionarem igualmente.