### PR TITLE
Customize error message on checkout

### DIFF
--- a/app/code/community/PagarMe/Checkout/Model/Checkout.php
+++ b/app/code/community/PagarMe/Checkout/Model/Checkout.php
@@ -110,6 +110,15 @@ class PagarMe_Checkout_Model_Checkout extends Mage_Payment_Model_Method_Abstract
 
         $infoInstance->unsAdditionalInformation('token');
 
+        if (empty($token)) {
+            throw new \Exception(
+                Mage::helper('pagarme_checkout')->__(
+                    'Error, please review your payment info'
+                ),
+                1
+            );
+        }
+
         $pagarMeSdk = Mage::getModel('pagarme_core/sdk_adapter')
             ->getPagarMeSdk();
 

--- a/app/code/community/PagarMe/Core/Model/Quote/Address/Total/Abstract.php
+++ b/app/code/community/PagarMe/Core/Model/Quote/Address/Total/Abstract.php
@@ -22,6 +22,10 @@ abstract class PagarMe_Core_Model_Quote_Address_Total_Abstract
             return false;
         }
 
+        if (empty($paymentData['pagarme_checkout_token'])) {
+            return false;
+        }
+
         return true;
     }
 

--- a/app/locale/pt_BR/PagarMe_Core.csv
+++ b/app/locale/pt_BR/PagarMe_Core.csv
@@ -23,3 +23,4 @@
 "Boleto Configurations", "Configurações de Boleto"
 "Visual Configurations", "Configurações Visuais"
 "Payment method title", "Título do meio de pagamento"
+"Error, please review your payment info","Falha no pagamento, por favor revise seus dados"

--- a/tests/acceptance/OneStepCheckoutContext.php
+++ b/tests/acceptance/OneStepCheckoutContext.php
@@ -277,11 +277,19 @@ class OneStepCheckoutContext extends RawMinkContext
      */
     public function placeOrder()
     {
+        $this->clickOnPlaceOrderButton();
+
+        $this->getSession()->wait(10000);
+    }
+
+    /**
+     * @When click on place order button
+     */
+    public function clickOnPlaceOrderButton()
+    {
         $this->getSession()->getPage()->pressButton(
             Mage::helper('pagarme_checkout')->__('Place Order')
         );
-
-        $this->getSession()->wait(10000);
     }
 
     /**
@@ -576,5 +584,36 @@ class OneStepCheckoutContext extends RawMinkContext
         $page->pressButton('Login');
 
         $this->getSession()->wait(2000);
+    }
+
+    /**
+     * @When select Pagar.me Checkout as payment method
+     */
+    public function selectPagarMeCheckoutAsPaymentMethod()
+    {
+        $this->getSession()->getPage()->find(
+            'css',
+            '#p_method_pagarme_checkout'
+        )->click();
+
+        $this->getSession()->wait(5000);
+    }
+
+    /**
+     * @Then an alert box must be displayed
+     */
+    public function anAlertBoxMustBeDisplayed()
+    {
+        \PHPUnit_Framework_TestCase::assertEquals(
+            $this->getSession()
+                ->getDriver()
+                ->getWebDriverSession()
+                ->getAlert_text(),
+            Mage::helper('pagarme_checkout')->__(
+                'Error, please review your payment info'
+            )
+        );
+
+        $this->getSession()->getDriver()->getWebDriverSession()->accept_alert();
     }
 }

--- a/tests/acceptance/features/one_step_checkout.feature
+++ b/tests/acceptance/features/one_step_checkout.feature
@@ -106,3 +106,9 @@ Feature: One Step Checkout Pagar.me
         When I confirm payment using "5" installments
         And place order
         Then the purchase must be created with success
+
+    Scenario: Show alert when payment information is not provided
+        Given I am on checkout page using Inovarti One Step Checkout
+        When select Pagar.me Checkout as payment method
+        And click on place order button
+        Then an alert box must be displayed


### PR DESCRIPTION
### Descrição

Personaliza o erro exibido no checkout ao prosseguir sem informar dados de pagamento no checkout Pagar.me 

### Testes Realizados

Adicionado teste funcional