### PR TITLE
Corrige atualização de status da Order após Transação ser aprovada

### DIFF
--- a/app/code/community/Inovarti/Pagarme/controllers/Transaction/CreditcardController.php
+++ b/app/code/community/Inovarti/Pagarme/controllers/Transaction/CreditcardController.php
@@ -33,7 +33,9 @@ class Inovarti_Pagarme_Transaction_CreditcardController
 
                 foreach ($order->getInvoiceCollection() as $invoice) {
                     $invoice->setRequestedCaptureCase(Mage_Sales_Model_Order_Invoice::CAPTURE_ONLINE);
-                    $invoice->capture();
+                    $invoice->pay();
+                    $invoice->getOrder()->setState(Mage_Sales_Model_Order::STATE_PROCESSING, true, 'Invoice defined as paid via Creditcard postback.');
+
                     Mage::getModel('core/resource_transaction')
                         ->addObject($invoice)
                         ->addObject($invoice->getOrder())
@@ -42,6 +44,7 @@ class Inovarti_Pagarme_Transaction_CreditcardController
 
                 $invoice->sendEmail();
                 $order->addStatusHistoryComment($this->__('Approved by Pagarme via Creditcard postback.'))->save();
+
                 return $this->getResponse()->setBody('ok');
             }
 


### PR DESCRIPTION
### Descrição

As Orders no Magento permaneciam com status `Payment Review`, com invoice em `Pending`, mesmo com a transação aprovada do lado do Pagar.me.

### Testes Realizados

- Testes manuais em ambiente local;
- Testes manuais em ambiente externo (MageCloud).
