### PR TITLE
Refactor/fix card hash generator

### DIFF
--- a/app/design/frontend/base/default/template/pagarme/form/cc.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/cc.phtml
@@ -166,6 +166,10 @@ Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
         pagarmeValidateFields();
     });
 
+    Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
+        pagarmeValidateFields();
+    })
+
     var changeElement = false;
     document.on('click', function(evt, elm){
         if (elm.match('#<?php echo $_code ?>_cc_number') || elm.match('#<?php echo $_code ?>_cc_owner') || elm.match('#<?php echo $_code ?>_cc_cid') ){

--- a/app/design/frontend/base/default/template/pagarme/form/cc.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/cc.phtml
@@ -92,15 +92,6 @@
         <label id="pagarme-cardhash-success" class="a-center" style="display:none;"><?php echo __('All right!'); ?></label>
     </li>
 </ul>
-<?php if($this->hasVerification()): ?>
-<script type="text/javascript">
-//<![CDATA[
-Event.observe($('<?php echo $_code ?>_cc_cid'), 'keyup', function(){
-    if (this.value.length > 3) $('<?php echo $_code ?>_installments').focus ();
-});
-//]]>
-</script>
-<?php endif; ?>
 <script type="text/javascript">
 //<![CDATA[
     pagarmeValidateFields = function() {


### PR DESCRIPTION
### Descrição

Realizei o pull request para resolver o erro de falta de dados de cartão no momento da finalização da compra no oneStepCheckout. 

### Testes Realizados

Utilizei cartões AMEX e Visa gerados de maneira aleatória para garantir que o cardHash esta sendo gerado corretamente antes da request ser enviada para pagar.me, monitorei este comportamento por meio do DevTools na aba Elements me atentando ao seguinte elemento: pagarme_cc_pagarme_card_hash.

Quando se trata de cartão AMEX o card_hash irá ser gerado após a inserção do 4º dígito e quando for Visa, Master e outros o card_hash irá ser gerado após a inserção do 3º dígito

Versões:
- Módulo: V1
- Inovarti oneStepCheckout: 6
- Magento: 1.9.2.4, 1.9.3.2