### PR TITLE
Fix installments calculation by wrong discount application

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@
 
 ## Observações
 * Por padrão o modulo utiliza o campo ```taxvat``` como ```document_number``` e 4 linhas em um endereço(```Sistema > Configuração > Configuração do cliente > Opções de Nome e Endereço``` e o campo ```Número de linhas em um endereço de rua``` com valor ```4```) respectivamente a ```street```, ```street_number```, ```complementary``` e ```neighborhood```.  Mas não se preocupe, caso esteja utilizando diferente do padrão, você pode utilizar o observer ```pagarme_get_customer_info_from_order_after``` e definir os valores de acordo com o seu Magento
+
+## Tests
+wget https://phar.phpunit.de/phpunit-4.1.0.phar
+chmod +x phpunit-4.1.0.phar
+mv phpunit-4.1.0.phar /usr/bin/phpunit
+

--- a/app/code/community/Inovarti/Pagarme/Model/Quote/Address/Total/Fee.php
+++ b/app/code/community/Inovarti/Pagarme/Model/Quote/Address/Total/Fee.php
@@ -85,12 +85,12 @@ class Inovarti_Pagarme_Model_Quote_Address_Total_Fee extends Mage_Sales_Model_Qu
         return $paymentMethod == 'pagarme_checkout' || $paymentMethod == 'pagarme_cc';
     }
 
-    private function getInstallmentConfig($paymentMethod)
+    public function getInstallmentConfig($paymentMethod)
     {
         if ($paymentMethod == 'pagarme_checkout') {
             return $this->getPagarMeCheckoutInstallmentConfig();
         } elseif ($paymentMethod == 'pagarme_cc') {
-            return $this->getPagarMeCcInstallmentConfig();
+            return Mage::getModel('pagarme/cc')->getPagarMeCcInstallmentConfig();
         }
         return null;
     }
@@ -101,16 +101,6 @@ class Inovarti_Pagarme_Model_Quote_Address_Total_Fee extends Mage_Sales_Model_Qu
         $config->setMaxInstallments((int) Mage::getStoreConfig('payment/pagarme_checkout/max_installments'));
         $config->setFreeInstallments((int) Mage::getStoreConfig('payment/pagarme_checkout/free_installments'));
         $config->setInterestRate((float) Mage::getStoreConfig('payment/pagarme_checkout/interest_rate'));
-
-        return $config;
-    }
-
-    private function getPagarMeCcInstallmentConfig()
-    {
-        $config = new Varien_Object();
-        $config->setMaxInstallments((int) Mage::getStoreConfig('payment/pagarme_cc/max_installments'));
-        $config->setFreeInstallments((int) Mage::getStoreConfig('payment/pagarme_cc/free_installments'));
-        $config->setInterestRate((float) Mage::getStoreConfig('payment/pagarme_cc/interest_rate'));
 
         return $config;
     }

--- a/tests/app/code/community/Inovarti/Pagarme/Block/Form/Inovarti_Pagarme_Block_Form_Cc_Test.php
+++ b/tests/app/code/community/Inovarti/Pagarme/Block/Form/Inovarti_Pagarme_Block_Form_Cc_Test.php
@@ -1,0 +1,200 @@
+<?php
+
+class Inovarti_Pagarme_Block_Form_Cc_Test extends \PHPUnit_Framework_TestCase
+{
+  	private $creditCardFormBlock = null;
+
+  	public function setUp()
+  	{
+        $this->creditCardFormBlock = $this->mockCardFormBlockMethods(['getPagarmeAPI']);
+  	}
+
+    public function mockCardFormBlockMethods($methods)
+    {
+        return $this->getMockBuilder('Inovarti_Pagarme_Block_Form_Cc')
+            ->setMethods($methods)
+            ->getMock();
+    }
+
+    public function getMockInstallment($amount, $quota)
+    {
+        $installment = new Varien_Object();
+        $installment->setInstallmentAmount($amount);
+        $installment->setInstallment($quota);
+
+        return $installment;
+    }
+
+    public function assertPreConditions()
+    {  
+        $this->assertInstanceOf(
+          $class = 'Inovarti_Pagarme_Block_Form_Cc',
+          $this->creditCardFormBlock,
+          "Expects instance of {$class}"
+        );
+
+        $this->assertEquals('pagarme_cc', Inovarti_Pagarme_Block_Form_Cc::PAYMENT_METHOD_TYPE);
+    }
+
+    public function getInstallmentsCollection($installments)
+    {
+        $installmentsCollection= new Varien_Object();
+        $installmentsCollection->setInstallments($installments);
+
+        return $installmentsCollection;
+    }
+
+    public function installmentesProvider()
+    {
+        $installment1 = $this->getMockInstallment(1000, 1);
+        $collection = [$installment1];
+        $installments = $this->getInstallmentsCollection($collection);
+        $expectOptionText = 'Pay in full - R$10.00';
+        $message = 'Pay in full option expected R$10.00';
+        $payFullOption = [$installments, $expectOptionText, $message];
+
+        $installment2 = $this->getMockInstallment(500, 2);
+        $installment3 = $this->getMockInstallment(333, 3);
+        $collection = array_merge($collection, [$installment2, $installment3]);
+        $installments = $this->getInstallmentsCollection($collection);
+        $expectOptionText = '3x - R$3.33 interest-free';
+        $message = '3th installment expected R$3.33';
+        $interestFreeOption = [$installments, $expectOptionText, $message];
+
+        $installment4 = $this->getMockInstallment(250, 4);
+        $installment5 = $this->getMockInstallment(200, 5);
+        $installment6 = $this->getMockInstallment(166, 6);
+        $collection = array_merge($collection, [$installment4, $installment5, $installment6]);
+        $installments = $this->getInstallmentsCollection($collection);
+        $expectOptionText = '6x - R$1.66 monthly interest rate (1.5%)';
+        $message = '6th installment expected R$1.66 with interest rate (1.5%)';
+        $interestRateOption = [$installments, $expectOptionText, $message];
+
+        return [$payFullOption, $interestFreeOption, $interestRateOption];
+    }
+
+    /**
+     * @dataProvider installmentesProvider
+     */
+    public function testGetInstallmentsAvailablesReturnDefaultOptionSuccessfully(
+      $installmentsCollection,
+      $expectOptionText,
+      $message
+    ) { 
+        $apiMock = $this->getMockBuilder('Inovarti_Pagarme_Model_Api')->getMock();
+        $apiMock->method('calculateInstallmentsAmount')->willReturn($installmentsCollection);
+        $this->creditCardFormBlock->method('getPagarmeAPI')->willReturn($apiMock);
+
+        $installments = $this->creditCardFormBlock->getInstallmentsAvailables();
+
+        $this->assertContains($expectOptionText, $installments, $message);
+    }
+
+    public function discountRulesProvider()
+    {
+        $creditCardMethod = Inovarti_Pagarme_Block_Form_Cc::PAYMENT_METHOD_TYPE;
+        $boletoMethod = 'pagarme_boleto';
+        $validade = false;
+        $expected = false;
+
+        $message = 'Expects not to give discount for differents payment methods';
+        $rulesNotValid = [$creditCardMethod, $validade, $expected, $message];
+
+        $validade = true;
+        $message = 'Expects not to give discount for invalid rules';
+        $differentsMethods = [$boletoMethod, $validade, $expected, $message];
+
+        $expected = true;
+        $message = 'Expects to give discount for the same payment methods and valid rules';
+        $discountSuccessfully = [$creditCardMethod, $validade, $expected, $message];
+
+        return [$differentsMethods, $rulesNotValid, $discountSuccessfully];
+    }
+
+    /**
+     * @dataProvider discountRulesProvider
+     */
+    public function testHasCreditCardDiscountRules(
+      $checkoutPaymentMethod,
+      $ruleValidade,
+      $expected,
+      $message
+    ) { 
+        $rulesMock = $this->getMockBuilder('Mage_SalesRule_Model_Rule')->getMock();
+        $rulesMock->method('validate')->willReturn($ruleValidade);
+        $paymentMock = new Varien_Object();
+        $paymentMock->setMethod($checkoutPaymentMethod);
+        $quoteMock = $this->getMockBuilder('Mage_Sales_Model_Quote')->getMock();
+        $quoteMock->method('getPayment')->willReturn($paymentMock);
+
+        $methods = ['getCheckoutQuote', 'getSalesRuleCollection'];
+        $this->creditCardFormBlock = $this->mockCardFormBlockMethods($methods);
+        $this->creditCardFormBlock->method('getCheckoutQuote')->willReturn($quoteMock);
+        $this->creditCardFormBlock->method('getSalesRuleCollection')->willReturn([$rulesMock]);
+
+        $hasDiscountRules = $this->creditCardFormBlock->hasCreditCardDiscountRules();
+        $this->assertEquals($expected, $hasDiscountRules, $message);
+    }
+
+    public function checkoutTotalAmountProvider()
+    { 
+        $shipping = 2;
+        $baseWithDiscount = 18;
+        $baseSubtotal = 10;
+        $hasDiscount = true;
+        $expected = 20;
+        $message = 'Expected to apply discount and billing shipping';
+        $discountChipping = [$baseSubtotal, $shipping, $baseWithDiscount, $hasDiscount, $expected, $message];
+
+        $shipping = 0;
+        $baseWithDiscount = 18;
+        $expected = 18;
+        $message = 'Expected to just apply the discount';
+        $discountOnly = [$baseSubtotal, $shipping, $baseWithDiscount, $hasDiscount, $expected, $message];
+
+        $shipping = 2;
+        $baseSubtotal = 20;
+        $hasDiscount = false;
+        $expected = 22;
+        $message = 'Expected base amount and billing shipping';
+        $baseAmountChipping = [$baseSubtotal, $shipping, $baseWithDiscount, $hasDiscount, $expected, $message];
+
+        $shipping = 0;
+        $baseSubtotal = 20;
+        $hasDiscount = false;
+        $expected = 20;
+        $message = 'Expected just the base amount';
+        $baseAmountOnly = [$baseSubtotal, $shipping, $baseWithDiscount, $hasDiscount, $expected, $message];
+
+        return [$discountChipping, $discountOnly, $baseAmountChipping, $baseAmountOnly];
+    }
+
+    /**
+     * @dataProvider checkoutTotalAmountProvider
+     **/
+    public function testgetCheckoutTotalAmount(
+      $baseSubtotal,
+      $shipping,
+      $baseWithDiscount,
+      $hasDiscount,
+      $expected,
+      $message
+    ) {
+        $shippingAmount = new Varien_Object();
+        $shippingAmount->setShippingAmount($shipping);
+        $quoteMock = $this->getMockBuilder('Mage_Sales_Model_Quote')
+        ->setMethods(['getBaseSubtotal', 'getBaseSubtotalWithDiscount', 'getShippingAddress'])
+        ->getMock();
+        $quoteMock->method('getBaseSubtotal')->willReturn($baseSubtotal);
+        $quoteMock->method('getBaseSubtotalWithDiscount')->willReturn($baseWithDiscount);
+        $quoteMock->method('getShippingAddress')->willReturn($shippingAmount);
+
+        $methods = ['getCheckoutQuote', 'hasCreditCardDiscountRules'];
+        $this->creditCardFormBlock = $this->mockCardFormBlockMethods($methods);
+        $this->creditCardFormBlock->method('getCheckoutQuote')->willReturn($quoteMock);
+        $this->creditCardFormBlock->method('hasCreditCardDiscountRules')->willReturn($hasDiscount);
+
+        $amount = $this->creditCardFormBlock->getCheckoutTotalAmount();
+        $this->assertEquals($expected, $amount, $message);
+    }
+}

--- a/tests/app/code/community/Inovarti/Pagarme/Model/Inovarti_Pagarme_Model_Cc_Test.php
+++ b/tests/app/code/community/Inovarti/Pagarme/Model/Inovarti_Pagarme_Model_Cc_Test.php
@@ -1,0 +1,49 @@
+<?php
+
+class Inovarti_Pagarme_Model_Cc_Test extends \PHPUnit_Framework_TestCase
+{
+  	private $creditCardModel = null;
+
+  	public function setUp()
+  	{
+        $this->creditCardModel = new Inovarti_Pagarme_Model_Cc;
+  	}
+
+  	public function installmentNumberProvider()
+  	{
+    	$config = new Varien_Object();
+        $config->setMaxInstallments(12);
+        $config->setMinInstallments(1);
+        $total = 1000;
+        $expected = 12;
+        $message = 'Expected customer max installments apply';
+        $maxInstallments = [$config, $total, $expected, $message];
+
+        $config = new Varien_Object();
+        $config->setMaxInstallments(5);
+        $config->setMinInstallments(3);
+        $total = 10;
+        $expected = 2;
+        $message = 'Expected intermediete installments apply';
+        $calculatedMinInstallments = [$config, $total, $expected, $message];
+
+        $config = new Varien_Object();
+        $config->setMaxInstallments(3);
+        $config->setMinInstallments(3);
+        $total = 3;
+        $expected = 1;
+        $message = 'Expected minimum installments apply';
+        $minInstallments = [$config, $total, $expected, $message];
+
+        return [$maxInstallments, $calculatedMinInstallments, $minInstallments];
+  	}
+
+  	/**
+  	 * @dataProvider installmentNumberProvider
+  	 **/
+  	public function testGetInstallmentNumber($installmentConfig, $total, $expected, $message)
+  	{
+    	$installmentNumber = $this->creditCardModel->getInstallmentNumber($total, $installmentConfig);
+    	$this->assertEquals($expected, $installmentNumber, $message);
+  	}
+}

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,0 +1,10 @@
+<?php
+$path = ini_get('include_path') . PATH_SEPARATOR;
+$path.= dirname(__FILE__) . '/../app' . PATH_SEPARATOR;
+$path.= dirname(__FILE__);
+
+ini_set('include_path', $path);
+ini_set('memory_limit', '512M');
+require_once 'Mage.php';
+Mage::app('default');
+session_start();

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="true"
+         bootstrap="./autoload.php">
+<testsuite name="Magento Unit Test">
+    <directory>./</directory>
+</testsuite>
+<filter>
+    <whitelist>
+        <directory suffix=".php">../app/code</directory>
+    </whitelist>
+</filter>
+</phpunit>


### PR DESCRIPTION
Discounted for payment using the boleto was identified exchanging the boleto
for credit card, continuing to display the amount discounted in the options of
installments.

Checks the payment rule to display the amount discounted in the options of
installments.

Removes duplicated codes
Changes code of  place to organize the codes
Creates tests to cover the changes

Issue: https://github.com/pagarme/pagarme-magento/issues/220