### PR TITLE
Pagarme checkout methods compatible with default payment method model…

### DIFF
--- a/app/code/community/Inovarti/Pagarme/Model/Checkout.php
+++ b/app/code/community/Inovarti/Pagarme/Model/Checkout.php
@@ -20,7 +20,7 @@ class Inovarti_Pagarme_Model_Checkout extends Inovarti_Pagarme_Model_Abstract
     protected $_canAuthorize                = true;
     protected $_canCapture                  = true;
     protected $_canRefund                   = true;
-    protected $_canUseForMultishipping        = true;
+    protected $_canUseForMultishipping      = true;
     protected $_canManageRecurringProfiles  = false;
 
     public function assignData($data)
@@ -37,7 +37,7 @@ class Inovarti_Pagarme_Model_Checkout extends Inovarti_Pagarme_Model_Abstract
         return $this;
     }
 
-    public function authorize(Varien_Object $payment)
+    public function authorize(Varien_Object $payment, $amount = 0)
     {
         $amount = $this->getGrandTotalFromPayment($payment);
 
@@ -45,7 +45,7 @@ class Inovarti_Pagarme_Model_Checkout extends Inovarti_Pagarme_Model_Abstract
         return $this;
     }
 
-    public function capture(Varien_Object $payment)
+    public function capture(Varien_Object $payment, $amount = 0)
     {
         $amount = $this->getGrandTotalFromPayment($payment);
 


### PR DESCRIPTION
Mage_Payment_Model_Method_Abstract::authorize()
Mage_Payment_Model_Method_Abstract::capture()

### Descrição

Ao instalar no Magento 1.9.3.6, com o developer mode ativo, ele dá as seguintes mensagens:

* Strict Notice: Declaration of Inovarti_Pagarme_Model_Checkout::authorize() should be compatible with Mage_Payment_Model_Method_Abstract::authorize(Varien_Object $payment, $amount)  in /var/www/html/app/code/community/Inovarti/Pagarme/Model/Checkout.php on line 10

* Strict Notice: Declaration of Inovarti_Pagarme_Model_Checkout::capture() should be compatible with Mage_Payment_Model_Method_Abstract::capture(Varien_Object $payment, $amount)  in /var/www/html/app/code/community/Inovarti/Pagarme/Model/Checkout.php on line 10

Só ajustei a declaração dos métodos, seguindo o padrão da classe abstrata do core.

@michelbrito 