### PR TITLE
creditcard: fix checkout pagarme to work with transparent

### DIFF
--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
+++ b/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
@@ -11,7 +11,7 @@
     </default>
     <checkout_onepage_index>
         <reference name="head">
-            <action method="addJs"><script>pagarme/creditcard.js</script></action>
+            <action method="addJs" ifconfig="payment/pagarme_settings/transparent_active"><script>pagarme/creditcard.js</script></action>
         </reference>
     </checkout_onepage_index>
 </layout>

--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -53,6 +53,7 @@ class CheckoutContext extends RawMinkContext
         $stock->assignProduct($this->product);
         $stock->save();
 
+        $this->disablePagarmeTransparent();
         $this->enablePagarmeCheckout();
     }
 

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -18,6 +18,8 @@ class CreditCardContext extends RawMinkContext
      */
     public function setUp()
     {
+        $config = Mage::getModel('core/config');
+
         $this->magentoUrl = getenv('MAGENTO_URL');
         $this->session = $this->getSession();
         $this->product = $this->getProduct();
@@ -114,8 +116,6 @@ class CreditCardContext extends RawMinkContext
     public function confirmBillingAndShippingAddressInformation()
     {
         $page = $this->session->getPage();
-
-        $this->session->wait(30000);
 
         $page->find('css', '#billing-buttons-container button')->press();
 


### PR DESCRIPTION
Pagar.me Checkout is not working when transparent checkout is enabled,
because the Place Order button is trying to generate card hash without
transparent checkout fields. This Pull Request make a condition to run
the credit card javascript only if the transparent checkout is active.