### PR TITLE
fix: Remove duplicated methods from tests contexts

### DIFF
--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -12,6 +12,7 @@ class CheckoutContext extends RawMinkContext
     use PagarMe\Magento\Test\Helper\ProductDataProvider;
     use PagarMe\Magento\Test\Helper\PagarMeSwitch;
     use PagarMe\Magento\Test\Helper\Configuration\Inovarti;
+    use PagarMe\Magento\Test\Helper\SessionWait;
 
     private $customer;
 
@@ -54,14 +55,6 @@ class CheckoutContext extends RawMinkContext
         $stock->save();
 
         $this->enablePagarmeCheckout();
-    }
-
-    public function waitForElement($element, $timeout)
-    {
-        $this->session->wait(
-            $timeout,
-            "document.querySelector('${element}').style.display != 'none'"
-        );
     }
 
     /**

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -12,6 +12,7 @@ class CreditCardContext extends RawMinkContext
     use PagarMe\Magento\Test\Helper\PagarMeSwitch;
     use PagarMe\Magento\Test\Helper\CustomerDataProvider;
     use PagarMe\Magento\Test\Helper\ProductDataProvider;
+    use PagarMe\Magento\Test\Helper\SessionWait;
 
     /**
      * @BeforeScenario
@@ -28,14 +29,6 @@ class CreditCardContext extends RawMinkContext
         $stock->save();
 
         $this->enablePagarmeTransparent();
-    }
-
-    public function waitForElement($element, $timeout)
-    {
-        $this->session->wait(
-            $timeout,
-            "document.querySelector('${element}').style.display != 'none'"
-        );
     }
 
     /**

--- a/tests/acceptance/Helper/SessionWait.php
+++ b/tests/acceptance/Helper/SessionWait.php
@@ -1,12 +1,11 @@
 <?php
-
 namespace PagarMe\Magento\Test\Helper;
 
-trait Interaction
+trait SessionWait
 {
     public function waitForElement($element, $timeout)
     {
-        $this->getSession()->wait(
+        $this->session->wait(
             $timeout,
             "document.querySelector('${element}').style.display != 'none'"
         );

--- a/tests/acceptance/OneStepCheckoutContext.php
+++ b/tests/acceptance/OneStepCheckoutContext.php
@@ -12,7 +12,7 @@ class OneStepCheckoutContext extends RawMinkContext
     use PagarMe\Magento\Test\Helper\CustomerDataProvider;
     use PagarMe\Magento\Test\Helper\PagarMeSettings;
     use PagarMe\Magento\Test\Helper\ProductDataProvider;
-    use PagarMe\Magento\Test\Helper\Interaction;
+    use PagarMe\Magento\Test\Helper\SessionWait;
     use PagarMe\Magento\Test\Helper\Configuration\Inovarti;
 
     protected $pagarMeCheckout;


### PR DESCRIPTION
### Descrição

There was a method `waitForElement` duplicated in different test files and
defined in a Trait named `Interaction`. This PR removes the duplicated ones and
rename the trait to `SessionWait` to improve code semantics

### Número da Issue

Não há issues 

### Testes Realizados

Nenhum teste adicionado

<!NÃO SE ESQUEÇA DE: Marcar um dos desenvolvedores do Pagar.me para review.>
