### PR TITLE
Implement installments on transparent checkout (credit card)

### DIFF
--- a/app/code/community/PagarMe/Core/Model/Transaction.php
+++ b/app/code/community/PagarMe/Core/Model/Transaction.php
@@ -9,4 +9,45 @@ class PagarMe_Core_Model_Transaction extends Mage_Core_Model_Abstract
     {
         return $this->_init('pagarme_core/transaction');
     }
+
+    /**
+     * @param Mage_Sales_Model_Order $order
+     * @param PagarMe\Sdk\Transaction\AbstractTransaction $transaction
+     * @param Mage_Sales_Model_Order_Payment $infoInstance
+     *
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    public function saveTransactionInformation(
+        Mage_Sales_Model_Order $order,
+        PagarMe\Sdk\Transaction\AbstractTransaction $transaction,
+        $infoInstance
+    ) {
+        $installments = 1;
+        $rateAmount = 0;
+        $interestRate = 0;
+        $totalAmount = Mage::helper('pagarme_core')
+            ->parseAmountToFloat($transaction->getAmount());
+
+        if ($transaction instanceof PagarMe\Sdk\Transaction\CreditCardTransaction) {
+            $installments = $transaction->getInstallments();
+
+            $rateAmount = ($totalAmount - $order->getBaseGrandTotal());
+            $interestRate = $infoInstance->getAdditionalInformation('interest_rate');
+        }
+
+        $this 
+            ->setTransactionId($transaction->getId())
+            ->setOrderId($order->getId())
+            ->setInstallments($installments)
+            ->setInterestRate($interestRate)
+            ->setPaymentMethod($transaction::PAYMENT_METHOD)
+            ->setFutureValue($totalAmount)
+            ->setRateAmount($rateAmount)
+            ->save();
+
+        $order->setGrandTotal($totalAmount);
+        $order->save();
+    }
 }

--- a/app/code/community/PagarMe/Core/Model/Transaction.php
+++ b/app/code/community/PagarMe/Core/Model/Transaction.php
@@ -30,7 +30,7 @@ class PagarMe_Core_Model_Transaction extends Mage_Core_Model_Abstract
         $totalAmount = Mage::helper('pagarme_core')
             ->parseAmountToFloat($transaction->getAmount());
 
-        if ($transaction instanceof PagarMe\Sdk\Transaction\AbstractTransaction) {
+        if ($transaction instanceof PagarMe\Sdk\Transaction\CreditCardTransaction) {
             $installments = $transaction->getInstallments();
 
             $rateAmount = ($totalAmount - $order->getBaseGrandTotal());

--- a/app/code/community/PagarMe/Core/Model/Transaction.php
+++ b/app/code/community/PagarMe/Core/Model/Transaction.php
@@ -30,7 +30,7 @@ class PagarMe_Core_Model_Transaction extends Mage_Core_Model_Abstract
         $totalAmount = Mage::helper('pagarme_core')
             ->parseAmountToFloat($transaction->getAmount());
 
-        if ($transaction instanceof PagarMe\Sdk\Transaction\CreditCardTransaction) {
+        if ($transaction instanceof PagarMe\Sdk\Transaction\AbstractTransaction) {
             $installments = $transaction->getInstallments();
 
             $rateAmount = ($totalAmount - $order->getBaseGrandTotal());

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -48,7 +48,8 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
     public function assignData($data)
     {
         $additionalInfoData = [
-            'card_hash' => $data['card_hash']
+            'card_hash' => $data['card_hash'],
+            'installments' => $data['installments']
         ];
 
         $this->getInfoInstance()
@@ -61,6 +62,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
     {
         $infoInstance = $this->getInfoInstance();
         $cardHash = $infoInstance->getAdditionalInformation('card_hash');
+        $installments = $infoInstance->getAdditionalInformation('installments');
         try {
             $card = Mage::getModel('pagarme_core/sdk_adapter')
                 ->getPagarMeSdk()
@@ -119,7 +121,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
                     $helper->parseAmountToInteger($quote->getGrandTotal()),
                     $card,
                     $customerPagarMe,
-                    1,
+                    $installments,
                     false
                 );
 

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -31,10 +31,10 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
     }
 
    /**
-     * Retrieve payment method title
-     *
-     * @return string
-     */
+    * Retrieve payment method title
+    *
+    * @return string
+    */
     public function getTitle()
     {
         return Mage::getStoreConfig(
@@ -100,7 +100,9 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
     {
         $infoInstance = $this->getInfoInstance();
         $cardHash = $infoInstance->getAdditionalInformation('card_hash');
-        $installments = (int)$infoInstance->getAdditionalInformation('installments');
+        $installments = (int)$infoInstance->getAdditionalInformation(
+            'installments'
+        );
 
         if (!$this->isInstallmentsValid($installments)) {
             return false;
@@ -115,7 +117,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
             $error = json_decode($exception->getMessage());
             $error = json_decode($error);
 
-            $response = array_reduce($error->errors, function($carry, $item) {
+            $response = array_reduce($error->errors, function ($carry, $item) {
                 return is_null($carry) ? $item->message : $carry."\n".$item->message;
             });
 
@@ -169,26 +171,27 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
                     false
                 );
 
-            $transaction = $pagarmeSdk->transaction()->capture($authorizedTransaction);
+            $transaction = $pagarmeSdk
+                ->transaction()
+                ->capture($authorizedTransaction);
+
             Mage::getModel('pagarme_core/transaction')
                 ->saveTransactionInformation(
-                    $order, 
-                    $transaction, 
+                    $order,
+                    $transaction,
                     $infoInstance
                 );
-
         } catch (\Exception $exception) {
             $json = json_decode($exception->getMessage());
             $json = json_decode($json);
 
-            $response = array_reduce($json->errors, function($carry, $item) {
+            $response = array_reduce($json->errors, function ($carry, $item) {
                 return is_null($carry)
                     ? $item->message : $carry."\n".$item->message;
             });
 
             Mage::throwException($response);
         }
-
 
         return $this;
     }
@@ -200,5 +203,4 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
             ->transaction()
             ->capture($authorizedTransaction);
     }
-    
 }

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -1,11 +1,10 @@
 <?php
-use Mage_Payment_Model_Method_Abstract as ModelMethodAbstract;
 use \PagarMe\Sdk\PagarMe as PagarMeSdk;
 use PagarMe_CreditCard_Model_Exception_InvalidInstallments as InvalidInstallmentsException;
 use PagarMe_CreditCard_Model_Exception_GenerateCard as GenerateCardException;
 use PagarMe_CreditCard_Model_Exception_TransactionsInstallmentsDivergent as TransactionsInstallmentsDivergent;
 
-class PagarMe_CreditCard_Model_Creditcard extends ModelMethodAbstract
+class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abstract
 {
     protected $_code = 'pagarme_creditcard';
     protected $_formBlockType = 'pagarme_creditcard/form_creditcard';

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -131,13 +131,13 @@ class PagarMe_CreditCard_Model_Creditcard extends ModelMethodAbstract
 
         if ($installments > self::PAGARME_MAX_INSTALLMENTS) {
             throw new InvalidInstallmentsException(
-                'Installments number should be lower than twelve'
+                'Installments number should be lower than Pagar.Me limit'
             );
         }
 
         if ($installments > $this->getMaxInstallments()) {
             $message = sprintf(
-                'Installments number should be greater than zero',
+                'Installments number should not be greater than %d',
                 $this->getMaxInstallments()
             );
             throw new InvalidInstallmentsException(
@@ -233,6 +233,12 @@ class PagarMe_CreditCard_Model_Creditcard extends ModelMethodAbstract
             $card = $this->generateCard($cardHash);
 
             if ($billingAddress == false) {
+                Mage::logException(
+                    sprintf(
+                        'Undefined Billing address: %s',
+                        $billingAddress
+                    )
+                );
                 return false;
             }
 
@@ -280,9 +286,11 @@ class PagarMe_CreditCard_Model_Creditcard extends ModelMethodAbstract
                     $infoInstance
                 );
         } catch (GenerateCardException $exception) {
-            Mage::throwException($exception->getMessage());
+            Mage::logException($exception->getMessage());
         } catch (InvalidInstallmentsException $exception) {
-            Mage::throwException($exception->getMessage());
+            Mage::logException($exception);
+        } catch (TransactionsInstallmentsDivergent $exception) {
+            Mage::logException($exception);
         } catch (\Exception $exception) {
             $json = json_decode($exception->getMessage());
             $json = json_decode($json);

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -112,6 +112,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
 
         $customerPagarMe = $helper->buildCustomer($customer);
 
+        $order = $payment->getOrder();
         try {
             $pagarmeSdk = Mage::getModel('pagarme_core/sdk_adapter')
                 ->getPagarMeSdk();
@@ -125,7 +126,8 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
                     false
                 );
 
-            $pagarmeSdk->transaction()->capture($authorizedTransaction);
+            $transaction = $pagarmeSdk->transaction()->capture($authorizedTransaction);
+            $this->saveTransactionInformation($order, $transaction, $infoInstance);
         } catch (\Exception $exception) {
             $json = json_decode($exception->getMessage());
             $json = json_decode($json);
@@ -148,5 +150,46 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
             ->getPagarMeSdk()
             ->transaction()
             ->capture($authorizedTransaction);
+    }
+    
+    /**
+     * @param Mage_Sales_Model_Order $order
+     * @param PagarMe\Sdk\Transaction\AbstractTransaction $transaction
+     * @param Mage_Sales_Model_Order_Payment $infoInstance
+     *
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    private function saveTransactionInformation(
+        Mage_Sales_Model_Order $order,
+        PagarMe\Sdk\Transaction\AbstractTransaction $transaction,
+        $infoInstance
+    ) {
+        $installments = 1;
+        $rateAmount = 0;
+        $interestRate = 0;
+        $totalAmount = Mage::helper('pagarme_core')
+            ->parseAmountToFloat($transaction->getAmount());
+
+        if ($transaction instanceof PagarMe\Sdk\Transaction\CreditCardTransaction) {
+            $installments = $transaction->getInstallments();
+
+            $rateAmount = ($totalAmount - $order->getBaseGrandTotal());
+            $interestRate = $infoInstance->getAdditionalInformation('interest_rate');
+        }
+
+        Mage::getModel('pagarme_core/transaction')
+            ->setTransactionId($transaction->getId())
+            ->setOrderId($order->getId())
+            ->setInstallments($installments)
+            ->setInterestRate($interestRate)
+            ->setPaymentMethod($transaction::PAYMENT_METHOD)
+            ->setFutureValue($totalAmount)
+            ->setRateAmount($rateAmount)
+            ->save();
+
+        $order->setGrandTotal($totalAmount);
+        $order->save();
     }
 }

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -30,7 +30,7 @@ class PagarMe_CreditCard_Model_Creditcard extends ModelMethodAbstract
 
     const PAGARME_MAX_INSTALLMENTS = 12;
 
-    public function __construct(PagarMeSdk $sdk = null)
+    public function __construct($attributes, PagarMeSdk $sdk = null)
     {
         if (is_null($sdk)) {
             $this->sdk = Mage::getModel('pagarme_core/sdk_adapter')
@@ -38,7 +38,7 @@ class PagarMe_CreditCard_Model_Creditcard extends ModelMethodAbstract
         }
 
         $this->pagarmeCoreHelper = Mage::helper('pagarme_core');
-        parent::__construct();
+        parent::__construct($attributes);
     }
 
     /**

--- a/app/code/community/PagarMe/CreditCard/Model/Exception/GenerateCard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Exception/GenerateCard.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @author LeonamDias <leonam.pd@gmail.com>
+ * @package PHP
+ */
+
+class PagarMe_CreditCard_Model_Exception_GenerateCard extends \Exception
+{
+}

--- a/app/code/community/PagarMe/CreditCard/Model/Exception/InvalidInstallments.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Exception/InvalidInstallments.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @author LeonamDias <leonam.pd@gmail.com>
+ * @package PHP
+ */
+
+class PagarMe_CreditCard_Model_Exception_InvalidInstallments extends \Exception
+{
+}

--- a/app/code/community/PagarMe/CreditCard/Model/Exception/TransactionsInstallmentsDivergent.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Exception/TransactionsInstallmentsDivergent.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @author LeonamDias <leonam.pd@gmail.com>
+ * @package PHP
+ */
+
+class PagarMe_CreditCard_Model_Exception_TransactionsInstallmentsDivergent extends \Exception
+{
+}

--- a/app/code/community/PagarMe/Modal/Model/Modal.php
+++ b/app/code/community/PagarMe/Modal/Model/Modal.php
@@ -149,7 +149,12 @@ class PagarMe_Modal_Model_Modal extends Mage_Payment_Model_Method_Abstract
             $this->extractAdditionalInfo($infoInstance, $transaction, $order)
         );
 
-        $this->saveTransactionInformation($order, $transaction, $infoInstance);
+        Mage::getModel('pagarme_core/transaction')
+            ->saveTransactionInformation(
+                $order, 
+                $transaction, 
+                $infoInstance
+            );
 
         return $this;
     }
@@ -178,45 +183,5 @@ class PagarMe_Modal_Model_Modal extends Mage_Payment_Model_Method_Abstract
             $data
         );
     }
-
-    /**
-     * @param Mage_Sales_Model_Order $order
-     * @param PagarMe\Sdk\Transaction\AbstractTransaction $transaction
-     * @param Mage_Sales_Model_Order_Payment $infoInstance
-     *
-     * @return void
-     *
-     * @codeCoverageIgnore
-     */
-    private function saveTransactionInformation(
-        Mage_Sales_Model_Order $order,
-        PagarMe\Sdk\Transaction\AbstractTransaction $transaction,
-        $infoInstance
-    ) {
-        $installments = 1;
-        $rateAmount = 0;
-        $interestRate = 0;
-        $totalAmount = Mage::helper('pagarme_core')
-            ->parseAmountToFloat($transaction->getAmount());
-
-        if ($transaction instanceof PagarMe\Sdk\Transaction\CreditCardTransaction) {
-            $installments = $transaction->getInstallments();
-
-            $rateAmount = ($totalAmount - $order->getBaseGrandTotal());
-            $interestRate = $infoInstance->getAdditionalInformation('interest_rate');
-        }
-
-        Mage::getModel('pagarme_core/transaction')
-            ->setTransactionId($transaction->getId())
-            ->setOrderId($order->getId())
-            ->setInstallments($installments)
-            ->setInterestRate($interestRate)
-            ->setPaymentMethod($transaction::PAYMENT_METHOD)
-            ->setFutureValue($totalAmount)
-            ->setRateAmount($rateAmount)
-            ->save();
-
-        $order->setGrandTotal($totalAmount);
-        $order->save();
-    }
+    
 }

--- a/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
@@ -69,7 +69,7 @@
         </label>
         <div class="input-box">
             <select
-                name="<?= $_code ?>_creditcard_installments"
+                name="payment[installments]"
                 id="<?= $_code ?>_creditcard_installments"
                 title="<?= $this->__('Installments') ?>"
                 class="input-text required-entry"

--- a/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
@@ -62,7 +62,25 @@
                 value=""
             />
         </div>
-    </li></ul>
+    </li>
+    <li>
+        <label for="<?= $_code ?>_creditcard_installments" class="required">
+            <em>*</em><?= $this->__('Installments') ?>
+        </label>
+        <div class="input-box">
+            <select
+                name="<?= $_code ?>_creditcard_installments"
+                id="<?= $_code ?>_creditcard_installments"
+                title="<?= $this->__('Installments') ?>"
+                class="input-text required-entry"
+            >
+            <?php for($i = 1; $i <= 12; $i++) : ?>
+                <option value="<?= $i ?>"><?= $i ?></option>
+            <?php endfor; ?>
+            </select>
+        </div>
+    </li>
+</ul>
 <div>
     <?= $this->getMethod()->getConfigData('message');?>
 </div>

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -130,6 +130,15 @@ class CreditCardContext extends RawMinkContext
 
         $page->find('css', '#p_method_pagarme_creditcard')->click();
     }
+    /**
+     * @When I choose :installments installments
+     */
+    public function iChooseInstallments($installments) {
+        $page = $this->session->getPage();
+        
+        $page->find('css', '#pagarme_creditcard_creditcard_installments')
+          ->selectOption('12');
+    }
 
     /**
      * @When I confirm my payment information

--- a/tests/acceptance/Helper/PagarMeSettings.php
+++ b/tests/acceptance/Helper/PagarMeSettings.php
@@ -24,7 +24,7 @@ trait PagarMeSettings
             'modal_payment_button_text' => '',
             'creditcard_interest_rate' => '0',
             'creditcard_free_installments' => '1',
-            'creditcard_max_installments' => '1',
+            'creditcard_max_installments' => '12',
             'creditcard_allowed_credit_card_brands' => 'visa,mastercard,amex,hipercard,aura,jcb,diners,elo',
             'modal_boleto_helper_text' => '',
             'modal_credit_card_helper_text' => '',

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -15,3 +15,16 @@ Feature: Credit Card
         And place order
         Then the purchase must be paid with success
 
+  
+    Scenario: Make a purchase in installment by credit card
+        Given a registered user
+        When I access the store page
+        And add any product to basket
+        And I go to checkout page
+        And login with registered user
+        And confirm billing and shipping address information
+        And choose pay with transparent checkout using credit card
+        And I choose "12" installments
+        And I confirm my payment information
+        And place order
+        Then the purchase must be paid with success

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -1,6 +1,6 @@
 Feature: Credit Card
     As an administrator of a webstore
-    I want to use the transparent checkout for credit card purchases without installments
+    I want to use the transparent checkout for credit card purchases with installments
     So that the clients on my store can buy their goods without knowing that the payment is resolved by Pagar.me
 
     Scenario: Make a purchase by credit card

--- a/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
+++ b/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
@@ -39,31 +39,28 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public function installments()
+    public function invalidInstallments()
     {
+        $installmentsBellowRange = 0;
+        $installmentsAboveRange = 7;
+        $installmentsAbovePagarmeRange = 13;
+
         return [
-            [0, false],
-            [5, true],
-            [7, false],
-            [13, false]
+            [$installmentsBellowRange],
+            [$installmentsAboveRange],
+            [$installmentsAbovePagarmeRange]
         ];
     }
     /**
      * @param int $installments
-     * @param bool $shouldReturn
      *
      * @test
-     * @dataProvider installments
+     * @dataProvider invalidInstallments
+     * @expectedException PagarMe_CreditCard_Model_Exception_InvalidInstallments
      */
-    public function installmentsMustBeInAValidRange(
-        $installments,
-        $shouldReturn
-    )
+    public function installmentsMustBeInAValidRange($installments)
     {
-        $this->assertEquals(
-            $shouldReturn,
-            $this->creditCardModel->isInstallmentsValid($installments)
-        );
+        $this->creditCardModel->isInstallmentsValid($installments);
     }
 
     public function getSdkMock($cardHash = '')

--- a/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
+++ b/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author LeonamDias <leonam.pd@gmail.com>
+ * @package PHP
+ */
+
+
+class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
+{
+    private $creditCardModel;
+
+    public function setUp()
+    {
+        $this->creditCardModel = $this->getMockBuilder(
+            'PagarMe_CreditCard_Model_Creditcard'
+        )->setMethods(['getMaxInstallments'])
+         ->getMock();
+
+        $this->creditCardModel
+            ->method('getMaxInstallments')
+            ->willReturn(6);
+    }
+
+    /**
+     * @test
+     */
+    public function mustBeAnInstanceOfPagarmeCreditCardModel()
+    {
+        $this->assertInstanceOf(
+            'PagarMe_CreditCard_Model_Creditcard',
+            $this->creditCardModel
+        );
+    }
+
+    public function installments()
+    {
+        return [
+            [0, false],
+            [5, true],
+            [7, false],
+            [13, false]
+        ];
+    }
+    /**
+     * @param int $installments
+     * @param bool $shouldReturn
+     *
+     * @test
+     * @dataProvider installments
+     */
+    public function installmentsMustBeInAValidRange($installments, $shouldReturn)
+    {
+        $this->assertEquals(
+            $shouldReturn,
+            $this->creditCardModel->isInstallmentsValid($installments)
+        );
+    }
+}

--- a/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
+++ b/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
@@ -5,7 +5,6 @@
  */
 
 use PagarMe\Sdk\Card\Card;
-use PagarMe_CreditCard_Model_Exception_TransactionsInstallmentsDivergent as TransactionsInstallmentsDivergent;
 use PagarMe\Sdk\Transaction\CreditCardTransaction;
 
 class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
@@ -17,7 +16,7 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
         $this->creditCardModel = $this->getMockBuilder(
             'PagarMe_CreditCard_Model_Creditcard'
         )->setMethods(['getMaxInstallments'])
-         ->getMock();
+        ->getMock();
 
         $this->creditCardModel
             ->method('getMaxInstallments')
@@ -43,14 +42,14 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
      */
     public function invalidInstallments()
     {
-        $installmentsBellowRange = 0;
-        $installmentsAboveRange = 7;
-        $installmentsAbovePagarmeRange = 13;
+        $installmentBellowRange = 0;
+        $installmentAboveRange = 7;
+        $installmentAbovePagarmeRange = 13;
 
         return [
-            [$installmentsBellowRange],
-            [$installmentsAboveRange],
-            [$installmentsAbovePagarmeRange]
+            [$installmentBellowRange],
+            [$installmentAboveRange],
+            [$installmentAbovePagarmeRange]
         ];
     }
     /**
@@ -68,22 +67,22 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
     public function getSdkMock($cardHash = '')
     {
         $sdkMock = $this->getMockBuilder('\PagarMe\Sdk\PagarMe')
-                        ->setMethods([
-                            'card',
-                            'createFromHash',
-                            'transaction',
-                            'creditCardTransaction'
-                        ])
-                        ->getMock();
+            ->setMethods([
+                'card',
+                'createFromHash',
+                'transaction',
+                'creditCardTransaction'
+            ])
+            ->getMock();
 
         $sdkMock->expects($this->any())
-                ->method('card')
-                ->willReturnSelf();
+            ->method('card')
+            ->willReturnSelf();
 
         $sdkMock->expects($this->any())
-                ->method('createFromHash')
-                ->with($cardHash)
-                ->willReturn(new Card([]));
+            ->method('createFromHash')
+            ->with($cardHash)
+            ->willReturn(new Card([]));
 
         return $sdkMock;
     }

--- a/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
+++ b/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
@@ -32,6 +32,12 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * Returns installments with expected return from isInstallmentsValid
+     * method
+     *
+     * @return array
+     */
     public function installments()
     {
         return [
@@ -48,7 +54,10 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
      * @test
      * @dataProvider installments
      */
-    public function installmentsMustBeInAValidRange($installments, $shouldReturn)
+    public function installmentsMustBeInAValidRange(
+        $installments,
+        $shouldReturn
+    )
     {
         $this->assertEquals(
             $shouldReturn,


### PR DESCRIPTION
### Description

Permit customers to buy with installmentes. This will use the  `max_installments` config to validate the installmentes defined by the customer and it needs to be lower than that.

### Issue

There's no issue

### Tests

Created unit and integration tests to validate the behavior described