### PR TITLE
Feature/osc adapts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e esse projeto adere ao [Semantic Versioning](http://semver.org/spec/v2
 .0.0
 .html).
 
+## [3.5.0] - 2018-02-19
+## [ADDED]
+- Compatibilidade com OSC6 no método cartão transparente
+
 ## [3.4.2] - 2018-01-30
 ## [FIXED]
 - Revisão das mensagens para tradução entre inglês e português (e vice versa)

--- a/app/code/community/PagarMe/Boleto/Model/Boleto.php
+++ b/app/code/community/PagarMe/Boleto/Model/Boleto.php
@@ -110,7 +110,7 @@ class PagarMe_Boleto_Model_Boleto extends Mage_Payment_Model_Method_Abstract
             $quote = Mage::getSingleton('checkout/session')->getQuote();
             $billingAddress = $quote->getBillingAddress();
             if ($billingAddress == false) {
-                Mage::logException(
+                Mage::log(
                     sprintf(
                         'Undefined Billing address: %s',
                         $billingAddress

--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.4.2</version>
+            <version>3.5.0</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
+++ b/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
@@ -26,7 +26,7 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
 
     public function getEncryptionKeyStoreConfig()
     {
-        return Mage::getStoreConfig(
+        return $this->getConfigurationWithName(
             'pagarme_configurations/general_encryption_key'
         );
     }

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.4.2</version>
+            <version>3.5.0</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -279,18 +279,22 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
             $this->capture($payment, $amount);
 
         } catch (GenerateCardException $exception) {
-            Mage::logException($exception->getMessage());
+            Mage::log($exception->getMessage());
+            Mage::logException($exception);
             Mage::throwException($exception);
         } catch (InvalidInstallmentsException $exception) {
+            Mage::log($exception->getMessage());
             Mage::logException($exception);
             Mage::throwException($exception);
         } catch (TransactionsInstallmentsDivergent $exception) {
+            Mage::log($exception->getMessage());
             Mage::logException($exception);
             Mage::throwException($exception);
         } catch (CantCaptureTransaction $exception) {
+            Mage::log($exception->getMessage());
             Mage::logException($exception);
         } catch (\Exception $exception) {
-            Mage::logException('Exception autorizing:');
+            Mage::log('Exception autorizing:');
             Mage::logException($exception);
             $json = json_decode($exception->getMessage());
             $json = json_decode($json);
@@ -322,7 +326,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
 
     private function throwBillingException($billingAddress)
     {
-        Mage::logException(
+        Mage::log(
             sprintf(
                 Mage::helper('pagarme_core')
                     ->__('Undefined Billing address: %s'),

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.4.2</version>
+            <version>3.5.0</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/Helper/Data.php
+++ b/app/code/community/PagarMe/Modal/Helper/Data.php
@@ -31,7 +31,8 @@ class PagarMe_Modal_Helper_Data extends Mage_Core_Helper_Abstract
                 return $this->transaction;
             }
         } catch (Exception $exception) {
-            Mage::logException($exception->getMessage());
+            Mage::log($exception->getMessage());
+            Mage::logException($exception);
         }
     }
 

--- a/app/code/community/PagarMe/Modal/Model/Modal.php
+++ b/app/code/community/PagarMe/Modal/Model/Modal.php
@@ -134,7 +134,8 @@ class PagarMe_Modal_Model_Modal extends Mage_Payment_Model_Method_Abstract
                 ['order_id' => $order->getIncrementId()]
             );
         } catch (\Exception $exception) {
-            \Mage::logException($exception->getMessage());
+            \Mage::log($exception->getMessage());
+            \Mage::logException($exception);
 
             throw $exception;
         }

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.4.2</version>
+            <version>3.5.0</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
+++ b/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
@@ -9,6 +9,11 @@
             </block>
         </reference>
     </default>
+    <onestepcheckout_index_index>
+        <reference name="head">
+            <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/creditcard-osc.js</script></action>
+        </reference>
+    </onestepcheckout_index_index>
     <checkout_onepage_index>
         <reference name="head">
             <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/creditcard.js</script></action>

--- a/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
@@ -97,6 +97,10 @@
         </div>
     </li>
 </ul>
+<script>
+    var pagarmeCreditcard = {}
+    pagarmeCreditcard.encryptionKey = "<?= $this->getEncryptionKeyStoreConfig(); ?>"
+</script>
 <div>
     <?= $this->getMethod()->getConfigData('message');?>
 </div>

--- a/js/pagarme/creditcard-osc.js
+++ b/js/pagarme/creditcard-osc.js
@@ -1,0 +1,58 @@
+const get = id => document.querySelector(id)
+
+const generateHash = () => {
+  const card = {
+    card_number: document.getElementById('pagarme_creditcard_creditcard_number').value,
+    card_holder_name: document.getElementById('pagarme_creditcard_creditcard_owner').value,
+    card_expiration_date: document.getElementById('pagarme_creditcard_creditcard_expiration_date').value,
+    card_cvv: document.getElementById('pagarme_creditcard_creditcard_cvv').value,
+  }
+
+  return pagarme.client.connect({
+    encryption_key: pagarmeCreditcard.encryptionKey
+  })
+    .then(client => client.security.encrypt(card))
+    .then((card_hash) => {
+      document.getElementById('pagarme_card_hash').value = card_hash
+    })
+}
+
+const clearHash = () => {
+  get('#pagarme_card_hash').value = ''
+}
+
+const pagarmeCreditcardSelected = () => {
+  return document.getElementById('p_method_pagarme_creditcard').checked
+}
+
+//imposes a order in the click event
+//tested only on click event
+eventAdded = false
+const eventBefore = (newFunction, event, prototypeElement) => {
+  if (eventAdded === false) {
+    const originalObservers = prototypeElement.getStorage()
+      .get('prototype_event_registry')
+      .get(event);
+    const newObserver = () => {
+      newFunction()
+      originalObservers.each((wrapper) => {
+        wrapper.handler()
+      })
+    }
+
+    prototypeElement.stopObserving(event)
+    prototypeElement.observe(event, newObserver)
+    eventAdded = true
+  }
+  return prototypeElement
+}
+
+document.onreadystatechange = () => {
+  const placeOrderButton = OSCForm.placeOrderButton
+  eventBefore(() => {
+    if (pagarmeCreditcardSelected()) {
+      clearHash()
+      generateHash()
+    }
+  }, 'click', placeOrderButton)
+}


### PR DESCRIPTION
### Description
Allows the use of the OSC6 module when the purchase is done via credit card.
Before this PR, since the URL for the OSC is differente from the default checkout, the js that generates the card hash wasn't included. Also,  even when included, since the structure of the checkout is different, I had to adapt the script to create the card hash when clicking the button and before the call to the placeOrder endpoint is made.
Also, the `Mage::logEsception` was being used wrongly - passing a string to it.

### Tests
Manual tests:
 - docker up with INSTALL_INOVARTI=true
 - Add a product, and configure the customer configurations
 - Buy the product with valid informations

Validated in a client
