### PR TITLE
Fix/order with initial paid status

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@
 [caso essa issue se trate de um bug, descreva como é o ambiente que ele ocorre, por exemplo:]
 
 * Magento Community 1.8.1.0
-* Módulo Pagar.me 0.1.7
+* Módulo Pagar.me 0.1.8
 * Servidor Linux
 * PHP 5.4
 * Apache 2.2

--- a/app/code/community/Inovarti/Pagarme/Model/Abstract.php
+++ b/app/code/community/Inovarti/Pagarme/Model/Abstract.php
@@ -112,8 +112,8 @@ abstract class Inovarti_Pagarme_Model_Abstract extends Inovarti_Pagarme_Model_Sp
 
         if ($this->getConfigData('async')) {
             $requestParams->setAsync(true);
-            $requestParams->setPostbackUrl(Mage::getUrl('pagarme/transaction_creditcard/postback'));
         }
+        $requestParams->setPostbackUrl(Mage::getUrl('pagarme/transaction_creditcard/postback'));
 
         $incrementId = $payment->getOrder()->getQuote()->getIncrementId();
         $requestParams->setMetadata(array('order_id' => $incrementId));
@@ -153,9 +153,7 @@ abstract class Inovarti_Pagarme_Model_Abstract extends Inovarti_Pagarme_Model_Sp
           );
         }
 
-        if ($this->getConfigData('async')) {
-            $payment->setIsTransactionPending(true);
-        }
+        $payment->setIsTransactionPending(true);
 
         $payment->setCcOwner($transaction->getCardHolderName())
             ->setCcLast4($transaction->getCardLastDigits())

--- a/app/code/community/Inovarti/Pagarme/etc/config.xml
+++ b/app/code/community/Inovarti/Pagarme/etc/config.xml
@@ -15,7 +15,7 @@
 <config>
     <modules>
         <Inovarti_Pagarme>
-            <version>0.1.7</version>
+            <version>0.1.8</version>
         </Inovarti_Pagarme>
     </modules>
     <global>


### PR DESCRIPTION
### Descrição

Chamados 04092917 e 04089390 do SalesForce

### Número da Issue

Sem Issue.

### Testes Realizados

Testes realizados com os parâmetros async e capture.

Nos cenários

| Async | Capture | Payment Method    |
|-------|---------|-------------------|
| true  | true    | Credit card       |
| true  | true    | Checkout Pagar.me |
| true  | false   | Credit card       |
| true  | false   | Checkout Pagar.me |
| false | true    | Credit card       |
| false | true    | Checkout Pagar.me |
| false | false   | Credit card       |
| false | false   | Checkout Pagar.me |

Em todos esses cenários, o status do pedido deve ser o mesmo, onde o primeiro status é Payment Review, e depois o status é atualizado via _POSTback_.

![image](https://user-images.githubusercontent.com/18074134/38738012-685685b8-3f07-11e8-9ab3-7e85ee30b968.png)

Para transações somente autorizadas, o pedido deve ter a opção de captura pela plataforma na opção Invoices do pedido.

![image](https://user-images.githubusercontent.com/18074134/38738231-fb954544-3f07-11e8-887d-05e6f24891e4.png)

O pedido também deve ser atualizado com sucesso quando a transação for capturada através da [dashboard](https://dashboard.pagar.me)
