### PR TITLE
tests: remove irrelevant outlines from installments scenario

### DIFF
--- a/tests/acceptance/features/configure.feature
+++ b/tests/acceptance/features/configure.feature
@@ -54,10 +54,6 @@ Feature: Configuration Form
         Examples:
         | interest_rate | free_installments | max_installments  |
         | 10            | 2                 | 12                |
-        | 3             | 5                 | 11                |
-        | 0             | 3                 | 3                 |
-        | 4             | 0                 | 1                 |
-        | 0             | 0                 | 1                 |
 
     Scenario: Setting up allowed credit card brands
         Given a admin user


### PR DESCRIPTION
### Description

Since this is a e2e test to validate that module configs works well,
execute the same test repeatedly with different values is irrelevant.