### PR TITLE
Remove the default order's status

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.5.3</version>
+            <version>3.5.4</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.5.3</version>
+            <version>3.5.4</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.5.3</version>
+            <version>3.5.4</version>
         </PagarMe_CreditCard>
     </modules>
     <global>
@@ -74,7 +74,6 @@
                 <model>pagarme_creditcard/creditcard</model>
                 <title>Credit Card</title>
                 <payment_action>authorize</payment_action>
-                <order_status>pending</order_status>
                 <allow_specific>0</allow_specific>
                 <sort_order>1</sort_order>
             </pagarme_creditcard>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.5.3</version>
+            <version>3.5.4</version>
         </PagarMe_Modal>
     </modules>
     <global>


### PR DESCRIPTION
### Descrição

Remove the default order's status because it was wrong and wasn't allowing to change the order status.

### Número da Issue

https://github.com/pagarme/pagarme-magento/issues/287

### Testes Realizados

No tests performed
