### PR TITLE
Fallback for credit card transactions timeout

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.6.0</version>
+            <version>3.7.0</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/Model/Sdk/Adapter.php
+++ b/app/code/community/PagarMe/Core/Model/Sdk/Adapter.php
@@ -9,9 +9,10 @@ class PagarMe_Core_Model_Sdk_Adapter extends Mage_Core_Model_Abstract
 
     /**
      * Timeout in seconds
+     *
      * @var int
      */
-    const SDK_TIMEOUT = 20;
+    const SDK_TIMEOUT = 15;
 
     public function _construct()
     {

--- a/app/code/community/PagarMe/Core/Model/Sdk/Adapter.php
+++ b/app/code/community/PagarMe/Core/Model/Sdk/Adapter.php
@@ -7,13 +7,19 @@ class PagarMe_Core_Model_Sdk_Adapter extends Mage_Core_Model_Abstract
      */
     private $pagarMeSdk;
 
+    /**
+     * Timeout in seconds
+     * @var int
+     */
+    const SDK_TIMEOUT = 20;
+
     public function _construct()
     {
         parent::_construct();
 
         $this->pagarMeSdk = new \PagarMe\Sdk\PagarMe(
             Mage::getStoreConfig('payment/pagarme_configurations/general_api_key'),
-            null,
+            self::SDK_TIMEOUT,
             $this->getUserAgent()
         );
     }

--- a/app/code/community/PagarMe/Core/Model/Transaction.php
+++ b/app/code/community/PagarMe/Core/Model/Transaction.php
@@ -4,6 +4,7 @@ use PagarMe_Core_Model_CurrentOrder as CurrentOrder;
 
 class PagarMe_Core_Model_Transaction extends Mage_Core_Model_Abstract
 {
+    const REFERENCE_KEY_MIN_LENGTH = 20;
 
     use PagarMe_Core_Trait_ConfigurationsAccessor;
 
@@ -13,6 +14,16 @@ class PagarMe_Core_Model_Transaction extends Mage_Core_Model_Abstract
     public function _construct()
     {
         return $this->_init('pagarme_core/transaction');
+    }
+
+    /**
+     * Creates a hash to be used as reference key
+     *
+     * @return string
+     */
+    public function getReferenceKey()
+    {
+        return md5(uniqid(rand()));
     }
 
     /**
@@ -54,6 +65,7 @@ class PagarMe_Core_Model_Transaction extends Mage_Core_Model_Abstract
 
         $this 
             ->setTransactionId($transaction->getId())
+            ->setReferenceKey($transaction->getReferenceKey())
             ->setOrderId($order->getId())
             ->setInstallments($installments)
             ->setInterestRate($interestRate)

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.6.0</version>
+            <version>3.7.0</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/sql/pagarme_core_setup/mysql4-install-3.5.5.php
+++ b/app/code/community/PagarMe/Core/sql/pagarme_core_setup/mysql4-install-3.5.5.php
@@ -1,0 +1,71 @@
+<?php
+
+$installer = $this;
+$installer->startSetup();
+
+$table = $installer->getConnection()
+    ->newTable($installer->getTable('pagarme_transaction'))
+    ->addColumn(
+        'reference_key',
+        Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        [
+            'nullable' => false,
+            'primary'  => true
+        ]
+    )
+    ->addColumn(
+        'order_id',
+        Varien_Db_Ddl_Table::TYPE_BIGINT,
+        null,
+        [
+            'unsigned' => true,
+            'nullable' => false,
+            'primary'  => true
+        ]
+    )
+    ->addColumn(
+        'transaction_id',
+        Varien_Db_Ddl_Table::TYPE_BIGINT,
+        null,
+        [
+            'unsigned' => true,
+            'nullable' => false,
+            'primary'  => true
+        ]
+    )
+    ->addColumn(
+        'installments',
+        Varien_Db_Ddl_Table::TYPE_SMALLINT,
+        1,
+        [
+            'nullable' => false,
+        ]
+    )
+    ->addColumn(
+        'interest_rate',
+        Varien_Db_Ddl_Table::TYPE_FLOAT,
+        null
+    )
+    ->addColumn(
+        'future_value',
+        Varien_Db_Ddl_Table::TYPE_FLOAT,
+        null
+    )
+    ->addColumn(
+        'rate_amount',
+        Varien_Db_Ddl_Table::TYPE_FLOAT,
+        null
+    )
+    ->addColumn(
+        'payment_method',
+        Varien_Db_Ddl_Table::TYPE_VARCHAR,
+        50,
+        [
+            'nullable' => false
+        ]
+    );
+
+$installer->getConnection()
+    ->createTable($table);
+
+$installer->endSetup();

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -283,7 +283,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
         $quote = Mage::getSingleton('checkout/session')->getQuote();
 
         $extraAttributes = array_merge(
-            $extraAttributes,
+            $extraAttributes
         );
 
         $this->transaction = $this->sdk
@@ -305,17 +305,18 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
 
     public function authorize(Varien_Object $payment, $amount)
     {
-        try {
-            $asyncTransaction = $this->getAsyncTransactionConfig();
-            $infoInstance = $this->getInfoInstance();
-            $cardHash = $infoInstance->getAdditionalInformation('card_hash');
-            $installments = (int)$infoInstance->getAdditionalInformation(
-                'installments'
-            );
+        $asyncTransaction = $this->getAsyncTransactionConfig();
+        $infoInstance = $this->getInfoInstance();
+        $order = $payment->getOrder();
+        $referenceKey = $this->getReferenceKey();
+        $cardHash = $infoInstance->getAdditionalInformation('card_hash');
+        $installments = (int)$infoInstance->getAdditionalInformation(
+            'installments'
+        );
 
-            $quote = Mage::getSingleton('checkout/session')->getQuote();
+        $quote = Mage::getSingleton('checkout/session')->getQuote();
 
-            $billingAddress = $quote->getBillingAddress();
+        $billingAddress = $quote->getBillingAddress();
 
         try {
             $this->isInstallmentsValid($installments);
@@ -351,9 +352,6 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
             );
 
             $this->checkInstallments($installments);
-
-            $order = $payment->getOrder();
-
 
             if(!$asyncTransaction)
             {

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -261,7 +261,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
         $installments = 1,
         $capture = false,
         $postbackUrl = null,
-        $async = []
+        $extraAttributes = []
     ) {
         $quote = Mage::getSingleton('checkout/session')->getQuote();
         $this->transaction = $this->sdk
@@ -274,7 +274,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
                 $installments,
                 $capture,
                 $postbackUrl,
-                $async
+                $extraAttributes
             );
 
         return $this;

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -256,6 +256,14 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
     }
 
     /**
+     * @return string
+     */
+    public function getReferenceKey()
+    {
+        return $this->transactionModel->getReferenceKey();
+    }
+
+    /**
      * @param \PagarMe\Sdk\Card\Card $card
      * @param \PagarMe\Sdk\Customer\Customer $customer
      * @param int $installments
@@ -273,11 +281,9 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
         $extraAttributes = []
     ) {
         $quote = Mage::getSingleton('checkout/session')->getQuote();
-        $referenceKey = $this->transactionModel->getReferenceKey();
 
         $extraAttributes = array_merge(
             $extraAttributes,
-            ['reference_key' => $referenceKey]
         );
 
         $this->transaction = $this->sdk
@@ -311,6 +317,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
 
             $billingAddress = $quote->getBillingAddress();
 
+        try {
             $this->isInstallmentsValid($installments);
             $card = $this->generateCard($cardHash);
 
@@ -329,6 +336,10 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
 
             $postbackUrl = $this->getUrlForPostback();
 
+            $extraAttributes = [
+                'async' => (bool)$asyncTransaction,
+                'reference_key' => $referenceKey
+            ];
             $this->createTransaction(
                 $card,
                 $customerPagarMe,
@@ -336,7 +347,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
                 true,
                 $postbackUrl,
                 [],
-                ['async' => (bool)$asyncTransaction]
+                $extraAttributes
             );
 
             $this->checkInstallments($installments);

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -240,9 +240,8 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
         $invoice->setGrandTotal($order->getGrandTotal());
         $invoice->setInterestAmount($order->getInterestAmount());
         $invoice->register()->pay();
-
         $invoice->setTransactionId($this->transaction->getId());
-        
+
         $order->setState(
             Mage_Sales_Model_Order::STATE_PROCESSING,
             true,
@@ -281,10 +280,6 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
         $extraAttributes = []
     ) {
         $quote = Mage::getSingleton('checkout/session')->getQuote();
-
-        $extraAttributes = array_merge(
-            $extraAttributes
-        );
 
         $this->transaction = $this->sdk
             ->transaction()
@@ -353,8 +348,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
 
             $this->checkInstallments($installments);
 
-            if(!$asyncTransaction)
-            {
+            if(!$asyncTransaction) {
                 $this->createInvoice($order);
             }
         } catch (GenerateCardException $exception) {
@@ -395,8 +389,9 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
         $this->transactionModel
             ->saveTransactionInformation(
                 $order,
-                $this->transaction,
-                $infoInstance
+                $infoInstance,
+                $referenceKey,
+                $this->transaction
             );
 
         return $this;
@@ -470,7 +465,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
                 Mage::helper('pagarme_core')
                     ->__('Invoice can\'t be refunded.')
             );
-        }                            
+        }
 
         $amount = ((float)$invoice->getGrandTotal()) * 100;
 

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.6.0</version>
+            <version>3.7.0</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/Model/Modal.php
+++ b/app/code/community/PagarMe/Modal/Model/Modal.php
@@ -94,6 +94,15 @@ class PagarMe_Modal_Model_Modal extends Mage_Payment_Model_Method_Abstract
     }
 
     /**
+     * @return string
+     */
+    public function getReferenceKey()
+    {
+        return \Mage::getModel('pagarme_core/transaction')
+            ->getReferenceKey();
+    }
+
+    /**
      * Authorize payment
      *
      * @param Varien_Object $payment
@@ -150,12 +159,13 @@ class PagarMe_Modal_Model_Modal extends Mage_Payment_Model_Method_Abstract
         $infoInstance->setAdditionalInformation(
             $this->extractAdditionalInfo($infoInstance, $transaction, $order)
         );
-
+        $referenceKey = $this->getReferenceKey();
         Mage::getModel('pagarme_core/transaction')
             ->saveTransactionInformation(
                 $order,
-                $transaction,
-                $infoInstance
+                $infoInstance,
+                $referenceKey,
+                $transaction
             );
 
         return $this;

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.6.0</version>
+            <version>3.7.0</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "pagarme/pagarme-php": "^3.4"
+        "pagarme/pagarme-php": "^3.7"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "79b5868272c7e3c20b1216041b654ca8",
-    "content-hash": "22f999f8846966ab7daa7e5b180d9096",
+    "hash": "c0e44beedc0ba222508c15cfff1a4b9a",
+    "content-hash": "91d01235bf5031a9a6c937a797b953a5",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -163,16 +163,16 @@
         },
         {
             "name": "pagarme/pagarme-php",
-            "version": "v3.7.5",
+            "version": "v3.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pagarme/pagarme-php.git",
-                "reference": "b2c71583db6741a5a27a95e4adeaf035a8628ddc"
+                "reference": "9bfbda3c57c75e82f243616dadeb5c5d6d2690ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pagarme/pagarme-php/zipball/b2c71583db6741a5a27a95e4adeaf035a8628ddc",
-                "reference": "b2c71583db6741a5a27a95e4adeaf035a8628ddc",
+                "url": "https://api.github.com/repos/pagarme/pagarme-php/zipball/9bfbda3c57c75e82f243616dadeb5c5d6d2690ba",
+                "reference": "9bfbda3c57c75e82f243616dadeb5c5d6d2690ba",
                 "shasum": ""
             },
             "require": {
@@ -205,7 +205,7 @@
                 "pagarme",
                 "payments brazil"
             ],
-            "time": "2018-03-22 20:50:14"
+            "time": "2018-06-05 20:20:20"
         },
         {
             "name": "react/promise",
@@ -677,16 +677,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "1.6.4",
+            "version": "1.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "86ad51e8a3c64c9782446aae740a61fc6faa2522"
+                "reference": "b184a92419cc9a9c4c6a09db555a94d441cb11c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/86ad51e8a3c64c9782446aae740a61fc6faa2522",
-                "reference": "86ad51e8a3c64c9782446aae740a61fc6faa2522",
+                "url": "https://api.github.com/repos/composer/composer/zipball/b184a92419cc9a9c4c6a09db555a94d441cb11c9",
+                "reference": "b184a92419cc9a9c4c6a09db555a94d441cb11c9",
                 "shasum": ""
             },
             "require": {
@@ -703,6 +703,9 @@
                 "symfony/filesystem": "^2.7 || ^3.0 || ^4.0",
                 "symfony/finder": "^2.7 || ^3.0 || ^4.0",
                 "symfony/process": "^2.7 || ^3.0 || ^4.0"
+            },
+            "conflict": {
+                "symfony/console": "2.8.38"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.35 || ^5.7",
@@ -750,7 +753,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2018-04-13 10:04:24"
+            "time": "2018-05-04 09:44:59"
         },
         {
             "name": "composer/semver",
@@ -816,16 +819,16 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "7e111c50db92fa2ced140f5ba23b4e261bc77a30"
+                "reference": "cb17687e9f936acd7e7245ad3890f953770dec1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/7e111c50db92fa2ced140f5ba23b4e261bc77a30",
-                "reference": "7e111c50db92fa2ced140f5ba23b4e261bc77a30",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/cb17687e9f936acd7e7245ad3890f953770dec1b",
+                "reference": "cb17687e9f936acd7e7245ad3890f953770dec1b",
                 "shasum": ""
             },
             "require": {
@@ -873,7 +876,7 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2018-01-31 13:17:27"
+            "time": "2018-04-30 10:33:04"
         },
         {
             "name": "container-interop/container-interop",
@@ -2000,16 +2003,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.9.3",
+            "version": "v0.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "79c280013cf0b30fa23f3ba8bd3649218075adf4"
+                "reference": "0951e91ac04ca28cf317f3997a0adfc319e80106"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/79c280013cf0b30fa23f3ba8bd3649218075adf4",
-                "reference": "79c280013cf0b30fa23f3ba8bd3649218075adf4",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/0951e91ac04ca28cf317f3997a0adfc319e80106",
+                "reference": "0951e91ac04ca28cf317f3997a0adfc319e80106",
                 "shasum": ""
             },
             "require": {
@@ -2021,9 +2024,9 @@
                 "symfony/var-dumper": "~2.7|~3.0|~4.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
                 "hoa/console": "~2.15|~3.16",
-                "phpunit/phpunit": "~4.8.35|~5.0|~6.0|~7.0",
-                "symfony/finder": "~2.1|~3.0|~4.0"
+                "phpunit/phpunit": "~4.8.35|~5.0|~6.0|~7.0"
             },
             "suggest": {
                 "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
@@ -2068,7 +2071,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2018-04-18 12:32:50"
+            "time": "2018-06-02 16:39:22"
         },
         {
             "name": "sebastian/comparator",
@@ -2636,7 +2639,7 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
@@ -2689,21 +2692,22 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "ecacddeaf76732231eea1657f6f5b062dade94c9"
+                "reference": "93bdf96d0e3c9b29740bf9050e7a996b443c8436"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/ecacddeaf76732231eea1657f6f5b062dade94c9",
-                "reference": "ecacddeaf76732231eea1657f6f5b062dade94c9",
+                "url": "https://api.github.com/repos/symfony/config/zipball/93bdf96d0e3c9b29740bf9050e7a996b443c8436",
+                "reference": "93bdf96d0e3c9b29740bf9050e7a996b443c8436",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
-                "symfony/filesystem": "~2.3|~3.0.0"
+                "symfony/filesystem": "~2.3|~3.0.0",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "require-dev": {
                 "symfony/yaml": "~2.7|~3.0.0"
@@ -2741,20 +2745,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2018-03-19 21:11:56"
+            "time": "2018-05-01 22:52:40"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7f78892d900c72a40acd1fe793c856ef0c110f26"
+                "reference": "e8e59b74ad1274714dad2748349b55e3e6e630c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7f78892d900c72a40acd1fe793c856ef0c110f26",
-                "reference": "7f78892d900c72a40acd1fe793c856ef0c110f26",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e8e59b74ad1274714dad2748349b55e3e6e630c7",
+                "reference": "e8e59b74ad1274714dad2748349b55e3e6e630c7",
                 "shasum": ""
             },
             "require": {
@@ -2768,7 +2772,7 @@
                 "symfony/process": "~2.1|~3.0.0"
             },
             "suggest": {
-                "psr/log": "For using the console logger",
+                "psr/log-implementation": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/process": ""
             },
@@ -2802,11 +2806,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03 05:20:27"
+            "time": "2018-05-15 21:17:45"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -2859,16 +2863,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "4486d2be5e068b51fece4c8551c14e709f573c8d"
+                "reference": "fe8838e11cf7dbaf324bd6f51d065d873ccf78a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/4486d2be5e068b51fece4c8551c14e709f573c8d",
-                "reference": "4486d2be5e068b51fece4c8551c14e709f573c8d",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/fe8838e11cf7dbaf324bd6f51d065d873ccf78a2",
+                "reference": "fe8838e11cf7dbaf324bd6f51d065d873ccf78a2",
                 "shasum": ""
             },
             "require": {
@@ -2912,11 +2916,11 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03 05:20:27"
+            "time": "2018-05-15 21:17:45"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
@@ -2979,7 +2983,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -3039,20 +3043,21 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "125403a59e4cb4e3ebf46d0162fabcde613d2b97"
+                "reference": "1ed4b265550ec43d2ceaa0e9e57b0bc4eeb1b541"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/125403a59e4cb4e3ebf46d0162fabcde613d2b97",
-                "reference": "125403a59e4cb4e3ebf46d0162fabcde613d2b97",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/1ed4b265550ec43d2ceaa0e9e57b0bc4eeb1b541",
+                "reference": "1ed4b265550ec43d2ceaa0e9e57b0bc4eeb1b541",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
@@ -3084,20 +3089,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-19 16:23:47"
+            "time": "2018-05-15 21:17:45"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "423746fc18ccf31f9abec43e4f078bb6e024b2d5"
+                "reference": "79764d21163db295f0daf8bd9d9b91f97e65db6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/423746fc18ccf31f9abec43e4f078bb6e024b2d5",
-                "reference": "423746fc18ccf31f9abec43e4f078bb6e024b2d5",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/79764d21163db295f0daf8bd9d9b91f97e65db6a",
+                "reference": "79764d21163db295f0daf8bd9d9b91f97e65db6a",
                 "shasum": ""
             },
             "require": {
@@ -3133,20 +3138,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-04 13:38:31"
+            "time": "2018-05-15 21:17:45"
         },
         {
             "name": "symfony/polyfill-apcu",
-            "version": "v1.7.0",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "e8ae2136ddb53dea314df56fcd88e318ab936c00"
+                "reference": "9b83bd010112ec196410849e840d9b9fefcb15ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/e8ae2136ddb53dea314df56fcd88e318ab936c00",
-                "reference": "e8ae2136ddb53dea314df56fcd88e318ab936c00",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/9b83bd010112ec196410849e840d9b9fefcb15ad",
+                "reference": "9b83bd010112ec196410849e840d9b9fefcb15ad",
                 "shasum": ""
             },
             "require": {
@@ -3155,7 +3160,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -3189,20 +3194,75 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-01-30 19:27:44"
+            "time": "2018-04-26 10:06:28"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.7.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
-                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-04-30 19:57:29"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "3296adf6a6454a050679cde90f95350ad604b171"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171",
+                "reference": "3296adf6a6454a050679cde90f95350ad604b171",
                 "shasum": ""
             },
             "require": {
@@ -3214,7 +3274,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -3248,20 +3308,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-01-30 19:27:44"
+            "time": "2018-04-26 10:06:28"
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "ee2c91470ff262b1a00aec27875d38594aa87629"
+                "reference": "713952f2ccbcc8342ecdbe1cb313d3e2da8aad28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/ee2c91470ff262b1a00aec27875d38594aa87629",
-                "reference": "ee2c91470ff262b1a00aec27875d38594aa87629",
+                "url": "https://api.github.com/repos/symfony/process/zipball/713952f2ccbcc8342ecdbe1cb313d3e2da8aad28",
+                "reference": "713952f2ccbcc8342ecdbe1cb313d3e2da8aad28",
                 "shasum": ""
             },
             "require": {
@@ -3297,20 +3357,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-03 05:20:27"
+            "time": "2018-05-15 21:17:45"
         },
         {
             "name": "symfony/translation",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "72235c1121ae282254e897e342c001f3d4bb7e8d"
+                "reference": "c6a27966a92fa361bf2c3a938abc6dee91f7ad67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/72235c1121ae282254e897e342c001f3d4bb7e8d",
-                "reference": "72235c1121ae282254e897e342c001f3d4bb7e8d",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/c6a27966a92fa361bf2c3a938abc6dee91f7ad67",
+                "reference": "c6a27966a92fa361bf2c3a938abc6dee91f7ad67",
                 "shasum": ""
             },
             "require": {
@@ -3327,7 +3387,7 @@
                 "symfony/yaml": "~2.2|~3.0.0"
             },
             "suggest": {
-                "psr/log": "To use logging capability in translator",
+                "psr/log-implementation": "To use logging capability in translator",
                 "symfony/config": "",
                 "symfony/yaml": ""
             },
@@ -3361,24 +3421,25 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-18 13:56:23"
+            "time": "2018-05-21 09:59:10"
         },
         {
             "name": "symfony/validator",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "e09bfa6273ee079662cb5b7ccd94a0a603062086"
+                "reference": "96bbfd5534d2e07ba45255bad27ee90d3bc121a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/e09bfa6273ee079662cb5b7ccd94a0a603062086",
-                "reference": "e09bfa6273ee079662cb5b7ccd94a0a603062086",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/96bbfd5534d2e07ba45255bad27ee90d3bc121a3",
+                "reference": "96bbfd5534d2e07ba45255bad27ee90d3bc121a3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
+                "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/translation": "~2.4|~3.0.0"
             },
@@ -3434,7 +3495,7 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-06 07:35:03"
+            "time": "2018-05-07 06:57:27"
         },
         {
             "name": "symfony/var-dumper",
@@ -3501,20 +3562,21 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.38",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "be720fcfae4614df204190d57795351059946a77"
+                "reference": "51356b7a2ff7c9fd06b2f1681cc463bb62b5c1ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/be720fcfae4614df204190d57795351059946a77",
-                "reference": "be720fcfae4614df204190d57795351059946a77",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/51356b7a2ff7c9fd06b2f1681cc463bb62b5c1ff",
+                "reference": "51356b7a2ff7c9fd06b2f1681cc463bb62b5c1ff",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
@@ -3546,7 +3608,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03 07:36:31"
+            "time": "2018-05-01 22:52:40"
         },
         {
             "name": "twig/twig",

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -345,7 +345,7 @@ class CreditCardContext extends RawMinkContext
      */
     public function thePurchaseMustBePaidWithSuccess()
     {
-        $this->session->wait(10000);
+        $this->session->wait(17000);
         $page = $this->session->getPage();
 
         $successMessage = $page->find('css', 'h1')

--- a/tests/unit/app/code/community/PagarMe/Core/Model/TransactionTest.php
+++ b/tests/unit/app/code/community/PagarMe/Core/Model/TransactionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+class PagarMeCoreModelTransactionTest extends PHPUnit_Framework_TestCase
+{
+    private $trxModel;
+
+    public function setUp()
+    {
+        $this->trxModel = new PagarMe_Core_Model_Transaction();
+    }
+
+    /**
+     * @test
+     */
+    public function mustReturnATransactionReferenceKeyHash()
+    {
+        $refKey = $this->trxModel->getReferenceKey();
+
+        $this->assertInternalType('string', $refKey);
+
+        $this->assertGreaterThanOrEqual(
+            PagarMe_Core_Model_Transaction::REFERENCE_KEY_MIN_LENGTH,
+            strlen($refKey),
+            sprintf(
+                'Failed asserting that reference key have %s caracters at least',
+                PagarMe_Core_Model_Transaction::REFERENCE_KEY_MIN_LENGTH
+            )
+        );
+    }
+}


### PR DESCRIPTION
### Description
Sometimes the Pagar.me's API takes too long time to respond requests. This causes a lot of problems for e-commerce that uses our module because when it occurs, the platform drops the connection and an error is showed to final user. Also, when a timeout occurs the final user clicks again on the place order button creating two transactions. Result: chargeback.

This PR implements a fallback that, when Pagar.me's API takes more than 15 seconds to respond, the platform will ignore the response and continues its workflow. The result will be received via postback (to be implemented).

### Tests
Manual tests