### PR TITLE
Fix show order details page

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.7.0</version>
+            <version>3.7.1</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.7.0</version>
+            <version>3.7.1</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/Block/Info/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Block/Info/Creditcard.php
@@ -61,4 +61,17 @@ class PagarMe_CreditCard_Block_Info_Creditcard extends Mage_Payment_Block_Info_C
             ->transaction()
             ->get($transactionId);
     }
+
+    /**
+     * Render the block only if there's a transaction object
+     *
+     * @return string
+     */
+    public function renderView()
+    {
+        if ($this->transaction) {
+            return parent::renderView();
+        }
+        return '';
+    }
 }

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.7.0</version>
+            <version>3.7.1</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.7.0</version>
+            <version>3.7.1</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/tests/unit/app/code/community/PagarMe/CreditCard/Block/Info/PagarMe_CreditCard_Block_Info_CreditcardTest.php
+++ b/tests/unit/app/code/community/PagarMe/CreditCard/Block/Info/PagarMe_CreditCard_Block_Info_CreditcardTest.php
@@ -1,0 +1,18 @@
+<?php
+
+class PagarMe_CreditCard_Block_Info_CreditcardTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     */
+    public function mustReturnEmptyStringWhenTheresNoTransaction()
+    {
+        $blockInfo = $this->getMockBuilder
+        (
+            'PagarMe_CreditCard_Block_Info_Creditcard'
+        )->disableOriginalConstructor()->getMock();
+
+        $this->assertEmpty($blockInfo->renderView());
+    }
+}


### PR DESCRIPTION
### Description

Fix issue #294 overriding the `renderView` method calling its parent
only if there's a transaction associated. If not, returns an empty
string

### Issue

#294 

### Tests

Unit test