### PR TITLE
Create minimum value per installment config

### DIFF
--- a/app/code/community/PagarMe/Core/etc/system.xml
+++ b/app/code/community/PagarMe/Core/etc/system.xml
@@ -77,12 +77,22 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </creditcard_max_installments>
+                        <creditcard_installments_min_value translate="label">
+                            <label>Installments minimum value</label>
+                            <comment>Installments value should be greater than this value</comment>
+                            <frontend_type>text</frontend_type>
+                            <frontend_class>validate-number</frontend_class>
+                            <sort_order>13</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </creditcard_installments_min_value>
                         <creditcard_interest_rate translate="label">
                             <label>Interest Rate (% per month)</label>
                             <comment>Example 1.99</comment>
                             <frontend_type>text</frontend_type>
                             <frontend_class>validate-number</frontend_class>
-                            <sort_order>13</sort_order>
+                            <sort_order>14</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
@@ -91,7 +101,7 @@
                             <label>Free Installments</label>
                             <frontend_type>text</frontend_type>
                             <frontend_class>validate-number</frontend_class>
-                            <sort_order>14</sort_order>
+                            <sort_order>15</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
@@ -100,7 +110,7 @@
                             <label>Allowed Credit Card Brands</label>
                             <frontend_type>multiselect</frontend_type>
                             <source_model>pagarme_core/system_config_source_creditCardBrands</source_model>
-                            <sort_order>15</sort_order>
+                            <sort_order>16</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>

--- a/app/locale/pt_BR/PagarMe_Core.csv
+++ b/app/locale/pt_BR/PagarMe_Core.csv
@@ -7,7 +7,8 @@
 "Use Pagar.me checkout to capture customer data","Capturar dados do cliente no Checkout Pagar.me"
 "Interest Rate (% per month)","Taxa de juros (% ao mês)"
 "Free Installments","Parcelas sem juros"
-"Max Installments","Número máximo de parcelas"
+"Max Installments","Número máximo de parcelas",
+"Installments minimum value","Valor mínimo por parcela",
 "Allowed Credit Card Brands","Bandeiras de cartão de crédito habilitadas"
 "Optional message for Boleto payment","Mensagem opcional para pagamento via boleto"
 "Optional message for Credit Card payment","Mensagem opcional para pagamento via cartão de crédito"

--- a/tests/acceptance/ConfigureContext.php
+++ b/tests/acceptance/ConfigureContext.php
@@ -350,6 +350,17 @@ class ConfigureContext extends RawMinkContext
     }
 
     /**
+     * @When I set installments minimum value to :installmentsMinValue
+     */
+    public function iSetInstallmentsMinimumValueTo($installmentsMinValue)
+    {
+        $this->getSession()->getPage()->fillField(
+            'payment_pagarme_configurations_creditcard_installments_min_value',
+            $installmentsMinValue
+        );
+    }
+
+    /**
      * @When change the checkout button text
      */
     public function changeTheCheckoutButtonText()

--- a/tests/acceptance/features/configure.feature
+++ b/tests/acceptance/features/configure.feature
@@ -26,6 +26,7 @@ Feature: Configuration Form
         And I set interest rate to "10"
         And I set free instalments to "2"
         And I set max instalments to "12"
+        And I set installments minimum value to "10"
         And I set boleto discount to "20.72"
         And I set boleto discount mode to "percentage"
         Then the configuration must be saved with success


### PR DESCRIPTION
### Description

It creates, on admin config panel, a new option to set the minimum amount
per installment. So, if the admin set this value to 50 BRL then a purchase of 100 BRL, could be done with two installments.

### Tests
 end to end tests