### PR TITLE
Fix one-step-checkout card hash generation

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.10.4</version>
+            <version>3.10.5</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.10.4</version>
+            <version>3.10.5</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.10.4</version>
+            <version>3.10.5</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.10.4</version>
+            <version>3.10.5</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
+++ b/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
@@ -17,6 +17,7 @@
     </onestepcheckout_index_index>
     <checkout_onepage_index>
         <reference name="head">
+            <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/cardhash.js</script></action>
             <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/creditcard.js</script></action>
         </reference>
     </checkout_onepage_index>

--- a/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
+++ b/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
@@ -11,6 +11,7 @@
     </default>
     <onestepcheckout_index_index>
         <reference name="head">
+            <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/cardhash.js</script></action>
             <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/creditcard-osc.js</script></action>
         </reference>
     </onestepcheckout_index_index>

--- a/js/pagarme/cardhash.js
+++ b/js/pagarme/cardhash.js
@@ -1,0 +1,20 @@
+const get = id => document.querySelector(id)
+
+const clearHash = () => {
+  get('#pagarme_card_hash').value = ''
+}
+
+const generateHash = () => {
+  const card = {
+    card_number: get('#pagarme_creditcard_creditcard_number').value,
+    card_holder_name: get('#pagarme_creditcard_creditcard_owner').value,
+    card_expiration_date: get('#pagarme_creditcard_creditcard_expiration_date').value,
+    card_cvv: get('#pagarme_creditcard_creditcard_cvv').value,
+  }
+  const encryptionKey = get('#pagarme_encryption_key').value
+  return pagarme.client.connect({ encryption_key: encryptionKey })
+    .then(client => client.security.encrypt(card))
+    .then((cardHash) => {
+      get('#pagarme_card_hash').value = cardHash
+    })
+}

--- a/js/pagarme/creditcard-osc.js
+++ b/js/pagarme/creditcard-osc.js
@@ -1,45 +1,26 @@
-const get = id => document.querySelector(id)
-
-const generateHash = () => {
-  const card = {
-    card_number: document.getElementById('pagarme_creditcard_creditcard_number').value,
-    card_holder_name: document.getElementById('pagarme_creditcard_creditcard_owner').value,
-    card_expiration_date: document.getElementById('pagarme_creditcard_creditcard_expiration_date').value,
-    card_cvv: document.getElementById('pagarme_creditcard_creditcard_cvv').value,
-  }
-  const encryptionKey = document.getElementById('pagarme_encryption_key').value
-  return pagarme.client.connect({
-    encryption_key: encryptionKey
-  })
-    .then(client => client.security.encrypt(card))
-    .then((card_hash) => {
-      document.getElementById('pagarme_card_hash').value = card_hash
-      console.log(card_hash)
-    })
-}
-
-const clearHash = () => {
-  get('#pagarme_card_hash').value = ''
-}
+var eventAdded = false
 
 const pagarmeCreditcardSelected = () => {
-  return document.getElementById('p_method_pagarme_creditcard').checked
+  return get('#p_method_pagarme_creditcard').checked
 }
 
 //imposes a order in the click event
 //tested only on click event
-eventAdded = false
 const eventBefore = (newFunction, event, prototypeElement) => {
   if (eventAdded === false) {
     const originalObservers = prototypeElement.getStorage()
       .get('prototype_event_registry')
-      .get(event);
+      .get(event)
     const newObserver = () => {
-      newFunction().then(() => {
+      newFunction()
+        .then(() => {
           originalObservers.each((wrapper) => {
-          wrapper.handler()
+            wrapper.handler()
+          })
         })
-      })
+        .catch((error) => {
+          console.error(error)
+        })
     }
 
     prototypeElement.stopObserving(event)
@@ -50,11 +31,12 @@ const eventBefore = (newFunction, event, prototypeElement) => {
 }
 
 document.onreadystatechange = () => {
-  const placeOrderButton = OSCForm.placeOrderButton
+  const { placeOrderButton } = OSCForm
   eventBefore(() => {
     if (pagarmeCreditcardSelected()) {
       clearHash()
       return generateHash()
     }
+    return Promise.reject(new Error('Can\'t generate the cardHash'))
   }, 'click', placeOrderButton)
 }

--- a/js/pagarme/creditcard-osc.js
+++ b/js/pagarme/creditcard-osc.js
@@ -7,13 +7,14 @@ const generateHash = () => {
     card_expiration_date: document.getElementById('pagarme_creditcard_creditcard_expiration_date').value,
     card_cvv: document.getElementById('pagarme_creditcard_creditcard_cvv').value,
   }
-
+  const encryptionKey = document.getElementById('pagarme_encryption_key').value
   return pagarme.client.connect({
-    encryption_key: pagarmeCreditcard.encryptionKey
+    encryption_key: encryptionKey
   })
     .then(client => client.security.encrypt(card))
     .then((card_hash) => {
       document.getElementById('pagarme_card_hash').value = card_hash
+      console.log(card_hash)
     })
 }
 
@@ -34,9 +35,10 @@ const eventBefore = (newFunction, event, prototypeElement) => {
       .get('prototype_event_registry')
       .get(event);
     const newObserver = () => {
-      newFunction()
-      originalObservers.each((wrapper) => {
-        wrapper.handler()
+      newFunction().then(() => {
+          originalObservers.each((wrapper) => {
+          wrapper.handler()
+        })
       })
     }
 
@@ -52,7 +54,7 @@ document.onreadystatechange = () => {
   eventBefore(() => {
     if (pagarmeCreditcardSelected()) {
       clearHash()
-      generateHash()
+      return generateHash()
     }
   }, 'click', placeOrderButton)
 }

--- a/js/pagarme/creditcard.js
+++ b/js/pagarme/creditcard.js
@@ -3,33 +3,33 @@ document.onreadystatechange = () => {
     // https://tc39.github.io/ecma262/#sec-array.prototype.includes
     if (!Array.prototype.includes) {
       Object.defineProperty(Array.prototype, 'includes', {
-        value: function(searchElement, fromIndex) {
+        value: function (searchElement, fromIndex) {
 
           // 1. Let O be ? ToObject(this value).
           if (this == null) {
             throw new TypeError('"this" is null or not defined');
           }
 
-          var o = Object(this);
+          var o = Object(this)
 
           // 2. Let len be ? ToLength(? Get(O, "length")).
-          var len = o.length >>> 0;
+          var len = o.length >>> 0
 
           // 3. If len is 0, return false.
           if (len === 0) {
-            return false;
+            return false
           }
 
           // 4. Let n be ? ToInteger(fromIndex).
           //    (If fromIndex is undefined, this step produces the value 0.)
-          var n = fromIndex | 0;
+          var n = fromIndex | 0
 
           // 5. If n ≥ 0, then
           //  a. Let k be n.
           // 6. Else n < 0,
           //  a. Let k be len + n.
           //  b. If k < 0, let k be 0.
-          var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+          var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0)
 
           // 7. Repeat, while k < len
           while (k < len) {
@@ -38,50 +38,29 @@ document.onreadystatechange = () => {
             // c. Increase k by 1.
             // NOTE: === provides the correct "SameValueZero" comparison needed here.
             if (o[k] === searchElement) {
-              return true;
+              return true
             }
-            k++;
+            k++
           }
 
           // 8. Return false
-          return false;
-        }
-      });
-    }
-
-    const get = id => document.querySelector(id)
-
-    const generateHash = () => {
-      const card = {
-        card_number: document.getElementById('pagarme_creditcard_creditcard_number').value,
-        card_holder_name: document.getElementById('pagarme_creditcard_creditcard_owner').value,
-        card_expiration_date: document.getElementById('pagarme_creditcard_creditcard_expiration_date').value,
-        card_cvv: document.getElementById('pagarme_creditcard_creditcard_cvv').value,
-      }
-      const encryptionKey = document.getElementById('pagarme_encryption_key').value
-      return pagarme.client.connect({ encryption_key: encryptionKey })
-        .then(client => client.security.encrypt(card))
-    .then((card_hash) => {
-        document.getElementById('pagarme_card_hash').value = card_hash
-    })
-    }
-
-    const clearHash = () => {
-      get('#pagarme_card_hash').value = ''
+          return false
+        },
+      })
     }
 
     var addedEvent = false
 
-    document.getElementById('opc-review').addEventListener('click', function(event) {
+    get('#opc-review').addEventListener('click', function (event) {
       if (event.path) {
         var buttons = this.getElementsByClassName('btn-checkout')
         const button = buttons[0]
         const buttonOnClick = button.onclick
 
-        for(var i = 0; i < event.path.length; i++) {
+        for (var i = 0; i < event.path.length; i++) {
           if (event.path[i].tagName == 'BUTTON' && !addedEvent) {
             event.path[i].onclick = null
-            event.path[i].addEventListener('click', function() {
+            event.path[i].addEventListener('click', function () {
               generateHash()
                 .then(() => buttonOnClick())
             })
@@ -94,13 +73,13 @@ document.onreadystatechange = () => {
         return
       }
 
-      if (event.target.tagName == 'BUTTON' && !addedEvent) {
+      if (event.target.tagName === 'BUTTON' && !addedEvent) {
         var buttons = this.getElementsByClassName('btn-checkout')
         const button = buttons[0]
         const buttonOnClick = button.onclick
 
         event.target.onclick = null
-        event.target.addEventListener('click', function() {
+        event.target.addEventListener('click', function () {
           generateHash()
             .then(() => buttonOnClick())
         })
@@ -109,7 +88,6 @@ document.onreadystatechange = () => {
 
         addedEvent = true
       }
-
     }, true)
   }
 }


### PR DESCRIPTION
### Description

The event trigger on one-step-checkout wasn't working well. To generate a card hash, there was an script that's responsible to retrieve the hash through Pagar.me's API and this should be performed before the default place order behavior. So this fixes using a promise to generate the card hash and then executes the place order event handlers.

Thanks, @henriquekano for the help!!

### Issue

#315 

### Tests

Manual and e2e tests
