### PR TITLE
Makes the module compatible with firecheckout

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.10.5</version>
+            <version>3.11.0</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.10.5</version>
+            <version>3.11.0</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.10.5</version>
+            <version>3.11.0</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.10.5</version>
+            <version>3.11.0</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
+++ b/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
@@ -15,6 +15,12 @@
             <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/creditcard-osc.js</script></action>
         </reference>
     </onestepcheckout_index_index>
+    <firecheckout_index_index>
+        <reference name="head">
+            <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/cardhash.js</script></action>
+            <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/creditcard.js</script></action>
+        </reference>
+    </firecheckout_index_index>
     <checkout_onepage_index>
         <reference name="head">
             <action method="addJs" ifconfig="payment/pagarme_configurations/transparent_active"><script>pagarme/cardhash.js</script></action>

--- a/js/pagarme/creditcard.js
+++ b/js/pagarme/creditcard.js
@@ -50,8 +50,7 @@ document.onreadystatechange = () => {
     }
 
     var addedEvent = false
-
-    get('#opc-review').addEventListener('click', function (event) {
+    get('#opc-review, #checkout-review-submit').addEventListener('click', function (event) {
       if (event.path) {
         var buttons = this.getElementsByClassName('btn-checkout')
         const button = buttons[0]


### PR DESCRIPTION
### Description

To create credit card transactions, the module should be capable of generate a [cardhash](https://docs.pagar.me/docs/overview-transacao#section-4-o-que-%C3%A9-um-card_hash). This generation is executed before the user clicks on Place order button. This event is attached to the button via its parent, that should be visible on the page, so. This use a generic parent id on the page `#checkout-review-submit` that is present on firecheckout page.

And to don't break users who uses the magento's default checkout, the event is attached to `#opc-review` too, that's the element visible on the page.

Also, to make this work on firecheckout it was necessary to add our javascript files to firecheckout page via xml configuration defining when and which block those files should be inserted.

### Tests

Manual tests.

**To-Do**: Automate firecheckout module and write some e2e tests.