### PR TITLE
Show unique id on order details page

### DIFF
--- a/app/code/community/PagarMe/Boleto/Block/Info/Boleto.php
+++ b/app/code/community/PagarMe/Boleto/Block/Info/Boleto.php
@@ -1,0 +1,30 @@
+<?php
+
+use PagarMe\Sdk\Transaction\BoletoTransaction;
+class PagarMe_Boleto_Block_Info_Boleto extends Mage_Payment_Block_Info
+{
+    /**
+     * @var BoletoTransaction
+     */
+    private $transaction;
+    private $helper;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setTemplate(
+            'pagarme/boleto/order_info/payment_details.phtml'
+        );
+        $this->helper = Mage::helper('pagarme_boleto');
+    }
+
+    public function transactionId()
+    {
+        return '1';
+    }
+
+    public function getBoletoUrl()
+    {
+        return 'http://pagar.me';
+    }
+}

--- a/app/code/community/PagarMe/Boleto/Block/Info/Boleto.php
+++ b/app/code/community/PagarMe/Boleto/Block/Info/Boleto.php
@@ -3,10 +3,8 @@
 use PagarMe\Sdk\Transaction\BoletoTransaction;
 class PagarMe_Boleto_Block_Info_Boleto extends Mage_Payment_Block_Info
 {
-    /**
-     * @var BoletoTransaction
-     */
-    private $transaction;
+    use PagarMe_Core_Block_Info_Trait;
+
     private $helper;
 
     public function __construct()
@@ -20,11 +18,11 @@ class PagarMe_Boleto_Block_Info_Boleto extends Mage_Payment_Block_Info
 
     public function transactionId()
     {
-        return '1';
+        return $this->getTransaction()->getId();
     }
 
     public function getBoletoUrl()
     {
-        return 'http://pagar.me';
+        return $this->getTransaction()->getBoletoUrl();
     }
 }

--- a/app/code/community/PagarMe/Boleto/Block/Info/Boleto.php
+++ b/app/code/community/PagarMe/Boleto/Block/Info/Boleto.php
@@ -1,6 +1,5 @@
 <?php
 
-use PagarMe\Sdk\Transaction\BoletoTransaction;
 class PagarMe_Boleto_Block_Info_Boleto extends Mage_Payment_Block_Info
 {
     use PagarMe_Core_Block_Info_Trait;

--- a/app/code/community/PagarMe/Boleto/Model/Boleto.php
+++ b/app/code/community/PagarMe/Boleto/Model/Boleto.php
@@ -5,6 +5,7 @@ class PagarMe_Boleto_Model_Boleto extends Mage_Payment_Model_Method_Abstract
 {
     protected $_code = 'pagarme_boleto';
     protected $_formBlockType = 'pagarme_boleto/form_boleto';
+    protected $_infoBlockType = 'pagarme_boleto/info_boleto';
     protected $_isGateway = true;
     protected $_canAuthorize = true;
     protected $_canCapture = true;

--- a/app/code/community/PagarMe/Core/Block/Info/Trait.php
+++ b/app/code/community/PagarMe/Core/Block/Info/Trait.php
@@ -1,0 +1,64 @@
+<?php
+
+trait PagarMe_Core_Block_Info_Trait
+{
+    /**
+     * @var \PagarMe\Sdk\Transaction\AbstractTransaction
+     */
+    private $transaction;
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return PagarMe\Sdk\Transaction\AbstractTransaction
+     * @throws \Exception
+     */
+    public function getTransaction()
+    {
+        if (!is_null($this->transaction)) {
+            return $this->transaction;
+        }
+
+        $pagarmeDbTransaction = $this->getTransactionIdFromDb();
+        $this->transaction = $this
+            ->fetchPagarmeTransactionFromAPi(
+                $pagarmeDbTransaction->getTransactionId()
+            );
+
+        return $this->transaction;
+    }
+
+    /**
+     * Retrieve transaction_id from database
+     *
+     * @return int
+     * @throws \Exception
+     */
+    private function getTransactionIdFromDb()
+    {
+        $order = $this->getInfo()->getOrder();
+
+        if (is_null($order)) {
+            throw new \Exception('Order doesn\'t exist');
+        }
+
+        return \Mage::getModel('pagarme_core/service_order')
+            ->getTransactionByOrderId(
+                $order->getId()
+            );
+    }
+
+    /**
+     * Fetch transaction's information from API
+     *
+     * @param int $transactionId
+     * @return \PagarMe\Sdk\Transaction\AbstractTransaction
+     */
+    private function fetchPagarmeTransactionFromAPi($transactionId)
+    {
+        return \Mage::getModel('pagarme_core/sdk_adapter')
+            ->getPagarMeSdk()
+            ->transaction()
+            ->get($transactionId);
+    }
+}

--- a/app/code/community/PagarMe/Core/Block/Info/Trait.php
+++ b/app/code/community/PagarMe/Core/Block/Info/Trait.php
@@ -1,16 +1,17 @@
 <?php
+use PagarMe\Sdk\Transaction\AbstractTransaction;
 
 trait PagarMe_Core_Block_Info_Trait
 {
     /**
-     * @var \PagarMe\Sdk\Transaction\AbstractTransaction
+     * @var AbstractTransaction
      */
     private $transaction;
 
     /**
      * @codeCoverageIgnore
      *
-     * @return PagarMe\Sdk\Transaction\AbstractTransaction
+     * @return AbstractTransaction
      * @throws \Exception
      */
     public function getTransaction()
@@ -19,11 +20,10 @@ trait PagarMe_Core_Block_Info_Trait
             return $this->transaction;
         }
 
-        $pagarmeDbTransaction = $this->getTransactionIdFromDb();
-        $this->transaction = $this
-            ->fetchPagarmeTransactionFromAPi(
-                $pagarmeDbTransaction->getTransactionId()
-            );
+        $transactionId = $this->getTransactionIdFromDb();
+        $this->transaction = $this->fetchPagarmeTransactionFromAPi(
+            $transactionId
+        );
 
         return $this->transaction;
     }
@@ -38,21 +38,19 @@ trait PagarMe_Core_Block_Info_Trait
     {
         $order = $this->getInfo()->getOrder();
 
-        if (is_null($order)) {
-            throw new \Exception('Order doesn\'t exist');
-        }
-
-        return \Mage::getModel('pagarme_core/service_order')
-            ->getTransactionByOrderId(
+        $pagarmeInfosRelated = \Mage::getModel('pagarme_core/service_order')
+            ->getInfosRelatedByOrderId(
                 $order->getId()
             );
+
+        return $pagarmeInfosRelated->getTransactionId();
     }
 
     /**
      * Fetch transaction's information from API
      *
      * @param int $transactionId
-     * @return \PagarMe\Sdk\Transaction\AbstractTransaction
+     * @return AbstractTransaction
      */
     private function fetchPagarmeTransactionFromAPi($transactionId)
     {

--- a/app/code/community/PagarMe/Core/Model/Service/Order.php
+++ b/app/code/community/PagarMe/Core/Model/Service/Order.php
@@ -35,13 +35,25 @@ class PagarMe_Core_Model_Service_Order
     }
 
     /**
-     * @codeCoverageIgnore
-     *
+     * @deprecated
+     * @see self::getInfosRelatedByOrderId
+     * @codeCoverageIgnore*
      * @param int $orderId
-     *
      * @return PagarMe_Core_Model_Transaction
      */
     public function getTransactionByOrderId($orderId)
+    {
+        return $this->getInfosRelatedByOrderId($orderId);
+    }
+
+    /**
+     * Retrieve pagarmes' info related to an order by its id
+     *
+     * @codeCoverageIgnore*
+     * @param int $orderId
+     * @return PagarMe_Core_Model_Transaction
+     */
+    public function getInfosRelatedByOrderId($orderId)
     {
         return Mage::getModel('pagarme_core/transaction')
             ->load($orderId, 'order_id');

--- a/app/code/community/PagarMe/CreditCard/Block/Info/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Block/Info/Creditcard.php
@@ -37,9 +37,8 @@ class PagarMe_CreditCard_Block_Info_Creditcard extends Mage_Payment_Block_Info_C
     }
 
     /**
-     * @codeCoverageIgnore
-     *
-     * @return PagarMe\Sdk\Transaction\CcTransaction
+     * @deprecated
+     * @see \PagarMe_Core_Block_Info_Trait::getTransaction()
      */
     public function getTransaction()
     {
@@ -50,6 +49,10 @@ class PagarMe_CreditCard_Block_Info_Creditcard extends Mage_Payment_Block_Info_C
             );
     }
 
+    /**
+     * @deprecated
+     * @see \PagarMe_Core_Block_Info_Trait::getTransactionIdFromDb()
+     */
     private function getPagePagarmeDbTransaction()
     {
         $order = $this->getInfo()->getOrder();
@@ -64,6 +67,10 @@ class PagarMe_CreditCard_Block_Info_Creditcard extends Mage_Payment_Block_Info_C
             );
     }
 
+    /**
+     * @deprecated
+     * @see \PagarMe_Core_Block_Info_Trait::fetchPagarmeTransactionFromAPi()
+     */
     private function fetchPagarmeTransactionFromAPi($transactionId)
     {
         return \Mage::getModel('pagarme_core/sdk_adapter')

--- a/app/code/community/PagarMe/CreditCard/Block/Info/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Block/Info/Creditcard.php
@@ -15,22 +15,34 @@ class PagarMe_CreditCard_Block_Info_Creditcard extends Mage_Payment_Block_Info_C
         $this->helper = Mage::helper('pagarme_creditcard');
     }
 
+    /**
+     * @return string
+     */
     public function transactionInstallments()
     {
         return $this->transaction->getInstallments();
     }
 
+    /**
+     * @return string
+     */
     public function transactionCustomerName()
     {
         $this->transaction = $this->getTransaction();
         return $this->transaction->getCustomer()->getName();
     }
 
+    /**
+     * @return string
+     */
     public function transactionCardBrand()
     {
         return $this->transaction->getCard()->getBrand();
     }
 
+    /**
+     * @return int
+     */
     public function transactionId()
     {
         return $this->transaction->getId();

--- a/app/code/community/PagarMe/CreditCard/Block/Info/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Block/Info/Creditcard.php
@@ -31,6 +31,11 @@ class PagarMe_CreditCard_Block_Info_Creditcard extends Mage_Payment_Block_Info_C
         return $this->transaction->getCard()->getBrand();
     }
 
+    public function transactionId()
+    {
+        return $this->transaction->getId();
+    }
+
     /**
      * @codeCoverageIgnore
      *

--- a/app/design/adminhtml/default/default/template/pagarme/boleto/order_info/payment_details.phtml
+++ b/app/design/adminhtml/default/default/template/pagarme/boleto/order_info/payment_details.phtml
@@ -15,7 +15,7 @@ $helper = Mage::helper('pagarme_boleto');
                 href="<?php echo $this->getBoletoUrl(); ?>"
                 target="_blank"
             >
-                Ver boleto
+                <?php echo $helper->__('Show boleto'); ?>
             </a>
         </td>
     </tr>

--- a/app/design/adminhtml/default/default/template/pagarme/boleto/order_info/payment_details.phtml
+++ b/app/design/adminhtml/default/default/template/pagarme/boleto/order_info/payment_details.phtml
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @see PagarMe_Boleto_Block_Info_Boleto
+ */
+$helper = Mage::helper('pagarme_boleto');
+?>
+
+<h3><?php echo $helper->__($this->getMethod()->getTitle()); ?></h3>
+<table id="pagarme_order_info_payment_details">
+    <tr>
+        <td>
+            <?php echo $helper->__('Boleto Url'); ?>
+        </td>
+        <td style="text-align: right" class="value">
+            <?php echo $this->getBoletoUrl(); ?>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <strong>
+                <?php echo $helper->__('Pagar.me Transaction Id');?>
+            </strong>
+        </td>
+        <td style="text-align:right;"><?= $this->transactionId(); ?></td>
+    </tr>
+</table>

--- a/app/design/adminhtml/default/default/template/pagarme/boleto/order_info/payment_details.phtml
+++ b/app/design/adminhtml/default/default/template/pagarme/boleto/order_info/payment_details.phtml
@@ -4,19 +4,23 @@
  */
 $helper = Mage::helper('pagarme_boleto');
 ?>
-
-<h3><?php echo $helper->__($this->getMethod()->getTitle()); ?></h3>
+<h3><?php echo $helper->__('Pagar.me Boleto'); ?></h3>
 <table id="pagarme_order_info_payment_details">
     <tr>
-        <td>
-            <?php echo $helper->__('Boleto Url'); ?>
+        <td class="label">
+            <strong><?php echo $helper->__('Boleto Url'); ?></strong>
         </td>
         <td style="text-align: right" class="value">
-            <?php echo $this->getBoletoUrl(); ?>
+            <a
+                href="<?php echo $this->getBoletoUrl(); ?>"
+                target="_blank"
+            >
+                Ver boleto
+            </a>
         </td>
     </tr>
     <tr>
-        <td>
+        <td class="label">
             <strong>
                 <?php echo $helper->__('Pagar.me Transaction Id');?>
             </strong>

--- a/app/design/adminhtml/default/default/template/pagarme/creditcard/order_info/payment_details.phtml
+++ b/app/design/adminhtml/default/default/template/pagarme/creditcard/order_info/payment_details.phtml
@@ -46,6 +46,14 @@
             <?= $this->transactionInstallments() ?>
         </td>
     </tr>
+    <tr>
+        <td>
+            <strong>
+                <?php echo $helper->__('Pagar.me Transaction Id');?>
+            </strong>
+        </td>
+        <td style="text-align:right;"><?= $this->transactionId(); ?></td>
+    </tr>
 </table>
 
 <br/>

--- a/app/locale/pt_BR/PagarMe_Core.csv
+++ b/app/locale/pt_BR/PagarMe_Core.csv
@@ -34,3 +34,7 @@
 "Invoice can\'t be refunded","Invoice não pode ser extornada"
 "There\'s no referenced order","Não existe uma order referenciada"
 "Refused by gateway.","Recusado pelo gateway."
+"Pagar.me Transaction Id","Id da transação no Pagar.me"
+"Boleto Url","Endereço do boleto (URL)"
+"Pagar.me Boleto","Boleto Pagar.me"
+"Show boleto","Ver boleto"


### PR DESCRIPTION
### Description

Show pagar.me `transaction_id` on payment block info. This shoul be visible on orders created via credit card or billet. Example:

Credit Card:
<img width="495" alt="captura de tela 2018-07-25 as 12 02 52" src="https://user-images.githubusercontent.com/1620107/43209839-04760232-9004-11e8-8378-2d2ea76384cb.png">

Billet:
<img width="490" alt="captura de tela 2018-07-25 as 12 02 31" src="https://user-images.githubusercontent.com/1620107/43209865-17016af4-9004-11e8-8f79-24466dc0d4f1.png">

### Tests

Manual tests