### PR TITLE
Handle refused status on credit card

### DIFF
--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -210,7 +210,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
             return $card;
         } catch (\Exception $exception) {
             $card = $this->getTestCard();
-            if($card instanceof \PagarMe\Sdk\Card\Card) {
+            if ($card instanceof \PagarMe\Sdk\Card\Card) {
                 return $card;
             }
             $json = json_decode($exception->getMessage());

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -1,6 +1,7 @@
 <?php
 use \PagarMe\Sdk\PagarMe as PagarMeSdk;
 use \PagarMe\Sdk\Card\Card as PagarmeCard;
+use \PagarMe\Sdk\Transaction\AbstractTransaction;
 use \PagarMe\Sdk\Transaction\CreditCardTransaction;
 use \PagarMe\Sdk\Customer\Customer as PagarmeCustomer;
 use \PagarMe\Sdk\PagarMeException;
@@ -366,9 +367,9 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
     )
     {
         switch ($transaction->getStatus()) {
+            case AbstractTransaction::PROCESSING:
+            case AbstractTransaction::REFUSED:
             case 'pending_review':
-            case 'processing':
-            case 'refused':
                 $payment->setIsTransactionPending(true);
                 break;
         }

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -368,6 +368,7 @@ class PagarMe_CreditCard_Model_Creditcard extends Mage_Payment_Model_Method_Abst
         switch ($transaction->getStatus()) {
             case 'pending_review':
             case 'processing':
+            case 'refused':
                 $payment->setIsTransactionPending(true);
                 break;
         }

--- a/app/code/community/PagarMe/CreditCard/Model/Observers/OrderObserver.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Observers/OrderObserver.php
@@ -12,14 +12,23 @@ class PagarMe_CreditCard_Model_Observers_OrderObserver
     {
         $order = $observer->getEvent()->getOrder();
         $pagarmeTransaction = $order->getPagarmeTransaction();
+
         if (!$pagarmeTransaction instanceof AbstractTransaction) {
             return;
         }
+
         if (
-            $order->getCapture() === 'authorize_capture' &&
+            $this->isAuthorizeAndCapture($order) &&
             $pagarmeTransaction->isPaid()
         ) {
             $this->createInvoice($order);
+        }
+
+        if (
+            $this->isAuthorizeAndCapture($order) &&
+            $pagarmeTransaction->isRefused()
+        ) {
+            $this->setStateForRefusedTransaction($order);
         }
     }
 
@@ -50,5 +59,42 @@ class PagarMe_CreditCard_Model_Observers_OrderObserver
             ->addObject($order)
             ->addObject($invoice)
             ->save();
+    }
+
+    /**
+     * Returns bool if the payment_action is authorize and capture
+     *
+     * @param \Mage_Sales_Model_Order $order
+     * @return bool
+     */
+    private function isAuthorizeAndCapture($order)
+    {
+        return $order->getCapture() == 'authorize_capture';
+    }
+
+    /**
+     * Update and insert a feedback about why an order is refused by gateway
+     *
+     * @param \Mage_Sales_Model_Order $order
+     * @return void
+     */
+    private function setStateForRefusedTransaction($order)
+    {
+        $transactionRefusedReason = $order
+            ->getPagarmeTransaction()
+            ->getRefuseReason();
+
+        $refusedMessage = sprintf(
+            'Refused by gateway. Reason: %s',
+            $transactionRefusedReason
+        );
+
+        $createCommentHistory = true;
+
+        $order->setState(
+            Mage_Sales_Model_Order::STATE_CANCELED,
+            $createCommentHistory,
+            Mage::helper('pagarme_core')->__($refusedMessage)
+        );
     }
 }


### PR DESCRIPTION
### Description

The module wasn't handling the transaction status if it's `refused`. That's was causing a problem that the order was created as `processing` and then through postback request its status was changed to `canceled`.

This PR fix the problem mentioned above setting the order as `pending` if its related transaction is `refused` and then, via an observer, create a comment history on admin panel describing the reason.

### Issue

#332 

### Tests

A unit test to validate the payment status handler. Also some manual tests to simulate refused transactions.