### PR TITLE
Implement a custom orders state/status workflow

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.13.1</version>
+            <version>3.14.0</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/Model/PostbackHandler/Authorized.php
+++ b/app/code/community/PagarMe/Core/Model/PostbackHandler/Authorized.php
@@ -3,9 +3,10 @@
 class PagarMe_Core_Model_PostbackHandler_Authorized extends PagarMe_Core_Model_PostbackHandler_Base
 {
     /**
-     * Given a paid postback the desired status on magento is processing
+     * Given a authorize postback the desired status on magento is
+     * pending_payment
      */
-    const MAGENTO_DESIRED_STATUS = Mage_Sales_Model_Order::STATE_PROCESSING;
+    const MAGENTO_DESIRED_STATUS = Mage_Sales_Model_Order::STATE_PENDING_PAYMENT;
 
     /**
      * Returns the desired state on magento

--- a/app/code/community/PagarMe/Core/Model/System/Config/Source/PaymentAction.php
+++ b/app/code/community/PagarMe/Core/Model/System/Config/Source/PaymentAction.php
@@ -2,6 +2,9 @@
 
 class PagarMe_Core_Model_System_Config_Source_PaymentAction
 {
+    const AUTH_ONLY = 'authorize_only';
+    const AUTH_CAPTURE = 'authorize_capture';
+
     /**
      * @codeCoverageIgnore
      *
@@ -11,12 +14,12 @@ class PagarMe_Core_Model_System_Config_Source_PaymentAction
     {
         return [
             [
-                'value' => 'authorize_capture',
+                'value' => self::AUTH_CAPTURE,
                 'label' => Mage::helper('pagarme_core')
                     ->__('Authorize and Capture')
             ],
             [
-                'value' => 'authorize_only',
+                'value' => self::AUTH_ONLY,
                 'label' => Mage::helper('pagarme_core')
                     ->__('Authorize Only')
             ]

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.13.1</version>
+            <version>3.14.0</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -101,7 +101,7 @@
             <pagarme_creditcard>
                 <active>1</active>
                 <model>pagarme_creditcard/creditcard</model>
-                <order_status>processing</order_status>
+                <order_status>pending_payment</order_status>
                 <allowspecific>0</allowspecific>
                 <payment_methods>credit_card</payment_methods>
                 <payment_action>authorize</payment_action>

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -405,7 +405,7 @@ class PagarMe_CreditCard_Model_Creditcard extends PagarMe_Core_Model_AbstractPay
         $refusedReason = $this->transaction->getRefuseReason();
         $refusedMessage = '';
         if ($refusedReason === 'acquirer') {
-            $refusedMessage .= ' Transaction unauthorized';
+            $refusedMessage .= ' Unauthorized';
         }
 
         if ($refusedReason === 'antifraud') {

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -421,7 +421,7 @@ class PagarMe_CreditCard_Model_Creditcard extends PagarMe_Core_Model_AbstractPay
      *
      * @return \Varien_Object
      */
-    public function handlePaymentStatus(
+    private function handlePaymentStatus(
         Mage_Sales_Model_Order_Payment $payment
     ) {
         $order = $payment->getOrder();

--- a/app/code/community/PagarMe/CreditCard/Model/Observers/OrderObserver.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Observers/OrderObserver.php
@@ -2,6 +2,9 @@
 
 use \PagarMe\Sdk\Transaction\AbstractTransaction;
 
+/**
+ * @deprecated
+ */
 class PagarMe_CreditCard_Model_Observers_OrderObserver
 {
 

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.13.1</version>
+            <version>3.14.0</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -22,16 +22,6 @@
                 </totals>
             </quote>
         </sales>
-        <events>
-            <sales_order_place_after>
-                <observers>
-                    <order_status> 
-                        <class>pagarme_creditcard/observers_orderObserver</class>
-                        <method>changeStatus</method>
-                    </order_status> 
-                </observers>
-            </sales_order_place_after>
-        </events>
         <models>
             <pagarme_creditcard>
                 <class>PagarMe_CreditCard_Model</class>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.13.1</version>
+            <version>3.14.0</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/locale/pt_BR/PagarMe_Creditcard.csv
+++ b/app/locale/pt_BR/PagarMe_Creditcard.csv
@@ -12,7 +12,7 @@
 "Pagar.me Credit card","Cartão de crédito Pagar.me"
 "Customer name","Nome do comprador"
 "Card brand","Bandeira do cartão",
-"Processing on gateway. Waiting response","Em processamento no gateway. Aguardando resposta"
+"Processing on Gateway. Waiting response","Em processamento no gateway. Aguardando resposta"
 "Transacion waiting review on Pagar.me's Dashboard","Transação Aguardando revisão na Dashboard Pagar.me"
 "Transaction refused by Gateway. Unauthorized","Transação recusada pelo Gateway. Não autorizada"
 "Transaction refused by Gateway. Suspected fraud","Transação recusada pelo Gateway. Suspeita de fraude"

--- a/app/locale/pt_BR/PagarMe_Creditcard.csv
+++ b/app/locale/pt_BR/PagarMe_Creditcard.csv
@@ -11,4 +11,10 @@
 "Credit Card","Cartão de Crédito"
 "Pagar.me Credit card","Cartão de crédito Pagar.me"
 "Customer name","Nome do comprador"
-"Card brand","Bandeira do cartão"
+"Card brand","Bandeira do cartão",
+"Processing on gateway. Waiting response","Em processamento no gateway. Aguardando resposta"
+"Transacion waiting review on Pagar.me's Dashboard","Transação Aguardando revisão na Dashboard Pagar.me"
+"Transaction refused by Gateway. Unauthorized","Transação recusada pelo Gateway. Não autorizada"
+"Transaction refused by Gateway. Suspected fraud","Transação recusada pelo Gateway. Suspeita de fraude"
+"Authorized amount of %s","Valor autorizado: %s"
+"Captured amount of %s","Valor capturado: %s"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c0e44beedc0ba222508c15cfff1a4b9a",
+    "hash": "d4c54286471c980e5b8f2cfeb9579aa9",
     "content-hash": "91d01235bf5031a9a6c937a797b953a5",
     "packages": [
         {
@@ -163,16 +163,16 @@
         },
         {
             "name": "pagarme/pagarme-php",
-            "version": "v3.7.8",
+            "version": "v3.7.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pagarme/pagarme-php.git",
-                "reference": "9bfbda3c57c75e82f243616dadeb5c5d6d2690ba"
+                "reference": "51e411bef2f2861c8caeaecafcdff8fadfc25f53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pagarme/pagarme-php/zipball/9bfbda3c57c75e82f243616dadeb5c5d6d2690ba",
-                "reference": "9bfbda3c57c75e82f243616dadeb5c5d6d2690ba",
+                "url": "https://api.github.com/repos/pagarme/pagarme-php/zipball/51e411bef2f2861c8caeaecafcdff8fadfc25f53",
+                "reference": "51e411bef2f2861c8caeaecafcdff8fadfc25f53",
                 "shasum": ""
             },
             "require": {
@@ -182,8 +182,8 @@
             "require-dev": {
                 "behat/mink-extension": "^2.2",
                 "ext-mbstring": "*",
-                "pagarme/git-hooks": "dev-master",
-                "phpunit/phpunit": "^4.8"
+                "phpunit/phpunit": "^4.8",
+                "squizlabs/php_codesniffer": "^3.3"
             },
             "type": "lib",
             "autoload": {
@@ -205,7 +205,7 @@
                 "pagarme",
                 "payments brazil"
             ],
-            "time": "2018-06-05 20:20:20"
+            "time": "2018-08-13 12:21:58"
         },
         {
             "name": "react/promise",

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -432,7 +432,6 @@ class CreditCardContext extends RawMinkContext
      */
     public function iGetTheCreatedOrderIdFromSuccessPage()
     {
-
         $this->waitForElement('.col-main', 3000);
         $page = $this->session->getPage();
         $feedbackMessage = $page->find(

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -1,9 +1,8 @@
 <?php
 
 use Behat\MinkExtension\Context\RawMinkContext;
-use Behat\Behat\Tester\Exception\PendingException;
-use PagarMe_Core_Model_CurrentOrder as CurrentOrder;
 use \PagarMe\Magento\Test\Order\OrderProvider;
+use PagarMe_Core_Model_System_Config_Source_PaymentAction as PaymentActionConfig;
 
 require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -198,7 +197,54 @@ class CreditCardContext extends RawMinkContext
             'payment/pagarme_configurations/creditcard_interest_rate',
             $interestRate
         );
+    }
 
+    /**
+     * @Given the administrator set payment action to :paymentAction and set async configuration to :isAsync
+     */
+    public function theAdministratorSetPaymentActionToAndSetAsyncConfigurationTo(
+        $paymentAction,
+        $isAsync
+    ) {
+        $config = Mage::getModel('core/config');
+
+        $config->saveConfig(
+            'payment/pagarme_configurations/payment_action',
+            $paymentAction
+        );
+
+        $asyncValue = ($isAsync === 'yes') ? '1' : '0';
+
+        $config->saveConfig(
+            'payment/pagarme_configurations/async_transaction',
+            $asyncValue
+        );
+    }
+
+    /**
+     * @Then the order status should be :expectedOrderState
+     */
+    public function theOrderStatusShouldBe($expectedOrderState)
+    {
+        $order = Mage::getModel('sales/order')
+            ->loadByIncrementId($this->createdOrderId);
+
+        PHPUnit_Framework_Assert::assertEquals(
+            $expectedOrderState,
+            $order->getState()
+        );
+
+        $config = Mage::getModel('core/config');
+
+        $config->saveConfig(
+            'payment/pagarme_configurations/payment_action',
+            PaymentActionConfig::AUTH_CAPTURE
+        );
+
+        $config->saveConfig(
+            'payment/pagarme_configurations/async_transaction',
+            0
+        );
     }
 
     /**
@@ -379,6 +425,23 @@ class CreditCardContext extends RawMinkContext
             ),
             strtolower($successMessage)
         );
+    }
+
+    /**
+     * @Then I get the created order id from success page
+     */
+    public function iGetTheCreatedOrderIdFromSuccessPage()
+    {
+
+        $this->waitForElement('.col-main', 3000);
+        $page = $this->session->getPage();
+        $feedbackMessage = $page->find(
+            'css',
+            '.col-main > p'
+        )->getText();
+
+        $orderId = preg_replace('/\D/', '', $feedbackMessage);
+        $this->createdOrderId = $orderId;
     }
 
     /**

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -3,8 +3,10 @@ Feature: Credit Card
     I want to use the transparent checkout for credit card purchases with installments
     So that the clients on my store can buy their goods without knowing that the payment is resolved by Pagar.me
 
-    Scenario: Make a purchase by credit card
+
+    Scenario Outline: Make a purchase by credit card
         Given a registered user
+        And the administrator set payment action to "<payment_action>" and set async configuration to "<isAsync>"
         When I access the store page
         And add any product to basket
         And I go to checkout page
@@ -14,6 +16,14 @@ Feature: Credit Card
         And I confirm my payment information
         And place order
         Then the purchase must be paid with success
+        And I get the created order id from success page
+        And the order status should be "<expected_order_status>"
+        Examples:
+        | payment_action    | isAsync | expected_order_status    |
+        | authorize_capture | no      | processing               |
+        | authorize_only    | no      | pending_payment          |
+        | authorize_only    | yes     | pending_payment          |
+        | authorize_capture | yes     | pending_payment          |
 
     Scenario Outline: Change the max installments configuration
         Given a registered user

--- a/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
+++ b/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
@@ -242,46 +242,4 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
         $creditCardModel->capture();
         $this->assertTrue($creditCardModel->transactionIsPaid());
     }
-
-    /**
-     * Returns status that should be used to set the payment object as Pending
-     *
-     * @return array
-     */
-    public function unpaidTransactions()
-    {
-        return [
-            [AbstractTransaction::REFUSED],
-            [AbstractTransaction::PROCESSING],
-            ['pending_review']
-        ];
-    }
-    /**
-     * @test
-     * @dataProvider unpaidTransactions
-     */
-    public function paymentShouldBePendingBasedOnItsUnpaidTransaction(
-        $unpaidStatus
-    )
-    {
-        $payment = Mage::getModel('sales/order_payment');
-
-        $transactionMock = $this->getMockBuilder('CreditCardTransaction')
-            ->disableOriginalConstructor()
-            ->setMethods(['getStatus', ])
-            ->getMock();
-
-        $transactionMock
-            ->method('getStatus')
-            ->willReturn($unpaidStatus);
-
-        $creditCardModel = Mage::getModel('pagarme_creditcard/creditcard');
-
-        $payment = $creditCardModel->handlePaymentStatus(
-            $transactionMock,
-            $payment
-        );
-
-        $this->assertTrue($payment->getIsTransactionPending());
-    }
 }


### PR DESCRIPTION
### Description

The platform order state/status workflow isn't compliance with Pagar.me transactions status. So this PR implement/customize the order's state workflow.

Give the admin can configure the module to create transactions on Pagar.me's service asynchronously, or authorize only the order status on the platform should be `pending_payment`:

---

**async=true and capture=false (authorize_only)**

![async](https://user-images.githubusercontent.com/1620107/44757155-0496a300-ab04-11e8-9a03-576a09e5ed9e.png)

---

**async=true and capture=true**

![capture-async](https://user-images.githubusercontent.com/1620107/44757042-702c4080-ab03-11e8-9a17-15c99153889a.png)

---

**async=false and capture=false (authorize_only)**

![authorized](https://user-images.githubusercontent.com/1620107/44757197-39a2f580-ab04-11e8-8c12-64146f8f7508.png)

---

Given the admin use the module configured to create transactions synchronously and capture the order state should be `processing`:

**async=false and capture=true**

![capture-sync](https://user-images.githubusercontent.com/1620107/44757214-4fb0b600-ab04-11e8-91c6-27f14b85a658.png)

---

### Tests

Manual tests and e2e tests to validate the expected behavior