### PR TITLE
Cartão de crédito: corrige o cálculo de juros

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.14.3</version>
+            <version>3.14.4</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/Block/Info/Trait.php
+++ b/app/code/community/PagarMe/Core/Block/Info/Trait.php
@@ -4,11 +4,6 @@ use PagarMe\Sdk\Transaction\AbstractTransaction;
 trait PagarMe_Core_Block_Info_Trait
 {
     /**
-     * @var AbstractTransaction
-     */
-    private $transaction;
-
-    /**
      * @codeCoverageIgnore
      *
      * @return AbstractTransaction

--- a/app/code/community/PagarMe/Core/Block/Info/Trait.php
+++ b/app/code/community/PagarMe/Core/Block/Info/Trait.php
@@ -34,7 +34,7 @@ trait PagarMe_Core_Block_Info_Trait
         $order = $this->getInfo()->getOrder();
 
         if (is_null($order)) {
-            throw new Exception('Order doesn\'t exist');
+            throw new \Exception('Order doesn\'t exist');
         }
 
         $pagarmeInfosRelated = \Mage::getModel('pagarme_core/service_order')
@@ -49,6 +49,7 @@ trait PagarMe_Core_Block_Info_Trait
      * Fetch transaction's information from API
      *
      * @param int $transactionId
+     *
      * @return AbstractTransaction
      */
     private function fetchPagarmeTransactionFromAPi($transactionId)

--- a/app/code/community/PagarMe/Core/Model/CurrentOrder.php
+++ b/app/code/community/PagarMe/Core/Model/CurrentOrder.php
@@ -51,8 +51,7 @@ class PagarMe_Core_Model_CurrentOrder
      */
     public function orderGrandTotalInCents()
     {
-        $quote = Mage::helper('checkout')->getQuote();
-        $total = $quote->getData()['grand_total'];
+        $total = $this->quote->getData()['grand_total'];
 
         return Mage::helper('pagarme_core')
             ->parseAmountToInteger($total);

--- a/app/code/community/PagarMe/Core/Model/CurrentOrder.php
+++ b/app/code/community/PagarMe/Core/Model/CurrentOrder.php
@@ -31,12 +31,27 @@ class PagarMe_Core_Model_CurrentOrder{
             );
     }
 
-    //Subtotal should be the sum of all items in the cart
-    //there's also Basesubtotal = subtotal in the store's currency
-    public function productsTotalValueInCents()
+    /**
+     *  @deprecated
+     *  @see self::productsTotalValueInCents
+     */
+    public function productsTotalValueInCents() {
+        return $this->orderGrandTotalInCents();
+    }
+
+    /**
+     * GrandTotal represents the value of the shipping + cart items total
+     * considering the discount amount
+     *
+     * @return int
+     */
+    public function orderGrandTotalInCents()
     {
-        $total = $this->quote->getTotals()['subtotal']->getValue();
-        return Mage::helper('pagarme_core')->parseAmountToInteger($total);
+        $quote = Mage::helper('checkout')->getQuote();
+        $total = $quote->getData()['grand_total'];
+
+        return Mage::helper('pagarme_core')
+            ->parseAmountToInteger($total);
     }
 
     public function productsTotalValueInBRL()

--- a/app/code/community/PagarMe/Core/Model/CurrentOrder.php
+++ b/app/code/community/PagarMe/Core/Model/CurrentOrder.php
@@ -1,6 +1,7 @@
 <?php
 
-class PagarMe_Core_Model_CurrentOrder{
+class PagarMe_Core_Model_CurrentOrder
+{
 
     /**
      * @var \Mage_Sales_Model_Quote
@@ -19,7 +20,7 @@ class PagarMe_Core_Model_CurrentOrder{
         $maxInstallments,
         $freeInstallments,
         $interestRate
-    ){
+    ) {
         $amount = $this->productsTotalValueInCents();
         return $this->pagarMeSdk->getPagarMeSdk()
             ->calculation()
@@ -32,10 +33,13 @@ class PagarMe_Core_Model_CurrentOrder{
     }
 
     /**
-     *  @deprecated
-     *  @see self::productsTotalValueInCents
+     * @deprecated
+     * @see self::productsTotalValueInCents
+     *
+     * @return int
      */
-    public function productsTotalValueInCents() {
+    public function productsTotalValueInCents()
+    {
         return $this->orderGrandTotalInCents();
     }
 
@@ -60,9 +64,20 @@ class PagarMe_Core_Model_CurrentOrder{
         return Mage::helper('pagarme_core')->parseAmountToFloat($total);
     }
 
-    //May result in slowing the payment method view in the checkout
-    public function rateAmountInBRL($installmentsValue, $freeInstallments, $interestRate)
-    {
+    /**
+     * May result in slowing the payment method view in the checkout
+     *
+     * @param int $installmentsValue
+     * @param int $freeInstallments
+     * @param float $interestRate
+     *
+     * @return float
+     */
+    public function rateAmountInBRL(
+        $installmentsValue,
+        $freeInstallments,
+        $interestRate
+    ) {
         $installments = $this->calculateInstallments(
             $installmentsValue,
             $freeInstallments,
@@ -71,6 +86,7 @@ class PagarMe_Core_Model_CurrentOrder{
 
         $installmentTotal = $installments[$installmentsValue]['total_amount'];
         return Mage::helper('pagarme_core')->parseAmountToFloat(
-            $installmentTotal - $this->productsTotalValueInCents());
+            $installmentTotal - $this->productsTotalValueInCents()
+        );
     }
 }

--- a/app/code/community/PagarMe/Core/Model/CurrentOrder.php
+++ b/app/code/community/PagarMe/Core/Model/CurrentOrder.php
@@ -1,8 +1,10 @@
 <?php
 
-class PagarMe_Core_Model_CurrentOrder
-{
+class PagarMe_Core_Model_CurrentOrder{
 
+    /**
+     * @var \Mage_Sales_Model_Quote
+     */
     private $quote;
     private $pagarMeSdk;
 

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.14.3</version>
+            <version>3.14.4</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/Block/Form/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Block/Form/Creditcard.php
@@ -17,7 +17,7 @@ class PagarMe_Creditcard_Block_Form_CreditCard extends Mage_Payment_Block_Form_C
 
     public function getInstallments()
     {
-        $quote = Mage::getModel('checkout/session')->getQuote();
+        $quote = Mage::helper('checkout')->getQuote();
         $pagarMeSdk = Mage::getModel('pagarme_core/sdk_adapter');
         $currentOrder = new CurrentOrder(
             $quote,

--- a/app/code/community/PagarMe/CreditCard/Model/Installments.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Installments.php
@@ -1,0 +1,53 @@
+<?php
+
+class PagarMe_CreditCard_Model_Installments
+{
+    private $sdk;
+
+    private $amount;
+    private $interestRate;
+    private $freeInstallments;
+    private $maxInstallments;
+
+    public function __construct(
+        $amount,
+        $installments,
+        $freeInstallments = 0,
+        $interestRate = 0,
+        $maxInstallments = 12,
+        $sdk = null
+    ) {
+        $this->sdk = $sdk;
+        if (is_null($sdk)) {
+            $this->sdk = Mage::getModel('pagarme_core/sdk_adapter')->getPagarmeSdk();
+        }
+
+        $this->amount = $amount;
+        $this->installments = $installments;
+        $this->freeInstallments = $freeInstallments;
+        $this->interestRate = $interestRate;
+        $this->maxInstallments = $maxInstallments;
+    }
+
+    private function calculate()
+    {
+        return $this->sdk
+            ->calculation()
+            ->calculateInstallmentsAmount(
+                $this->amount,
+                $this->interestRate,
+                $this->freeInstallments,
+                $this->maxInstallments
+            );
+    }
+
+    public function getTotal() {
+        return $this->getInstallmentTotalAmount($this->installments);
+    }
+
+    public function getInstallmentTotalAmount($installment) {
+        $installments = $this->calculate();
+
+        return $installments[$installment]['total_amount'];
+    }
+}

--- a/app/code/community/PagarMe/CreditCard/Model/Installments.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Installments.php
@@ -2,13 +2,39 @@
 
 class PagarMe_CreditCard_Model_Installments
 {
+    /**
+     * @var \PagarMe\Sdk\PagarMe
+     */
     private $sdk;
 
+    /**
+     * @var integer
+     */
     private $amount;
+
+    /**
+     * @var float
+     */
     private $interestRate;
+
+    /**
+     * @var integer
+     */
     private $freeInstallments;
+
+    /**
+     * @var integer
+     */
     private $maxInstallments;
 
+    /**
+     * @param int $amount
+     * @param int $installments
+     * @param int $freeInstallments
+     * @param float $interestRate
+     * @param int $maxInstallments
+     * @param \PagarMe\Sdk\PagarMe $sdk
+     */
     public function __construct(
         $amount,
         $installments,
@@ -18,10 +44,6 @@ class PagarMe_CreditCard_Model_Installments
         $sdk = null
     ) {
         $this->sdk = $sdk;
-        if (is_null($sdk)) {
-            $this->sdk = Mage::getModel('pagarme_core/sdk_adapter')->getPagarmeSdk();
-        }
-
         $this->amount = $amount;
         $this->installments = $installments;
         $this->freeInstallments = $freeInstallments;
@@ -29,6 +51,9 @@ class PagarMe_CreditCard_Model_Installments
         $this->maxInstallments = $maxInstallments;
     }
 
+    /**
+     * @return array
+     */
     private function calculate()
     {
         return $this->sdk
@@ -41,11 +66,21 @@ class PagarMe_CreditCard_Model_Installments
             );
     }
 
-    public function getTotal() {
+    /**
+     * @return int
+     */
+    public function getTotal()
+    {
         return $this->getInstallmentTotalAmount($this->installments);
     }
 
-    public function getInstallmentTotalAmount($installment) {
+    /**
+     * @param int $installment
+     *
+     * @return int
+     */
+    public function getInstallmentTotalAmount($installment)
+    {
         $installments = $this->calculate();
 
         return $installments[$installment]['total_amount'];

--- a/app/code/community/PagarMe/CreditCard/Model/Quote/Address/Total/CreditCardInterestAmount.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Quote/Address/Total/CreditCardInterestAmount.php
@@ -2,29 +2,47 @@
 
 use PagarMe_CreditCard_Model_Installments as Installments;
 
-class PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount
-    extends Mage_Sales_Model_Quote_Address_Total_Abstract
+// @codingStandardsIgnoreLine
+class PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount extends Mage_Sales_Model_Quote_Address_Total_Abstract
 {
 
     use PagarMe_Core_Trait_ConfigurationsAccessor;
 
+    /**
+     * @var float
+     */
     private $interestValue;
+
+    /**
+     * @param Mage_Sales_Model_Quote_Address $address
+     *
+     * @return bool
+     */
+    private function shouldCollect(Mage_Sales_Model_Quote_Address $address)
+    {
+        return $this->paymentMethodUsedWasPagarme($address) &&
+            $this->addressUsedIsShipping($address) &&
+            $this->wasCalledAfterPaymentMethodSelection() &&
+            $this->interestRateIsntZero() &&
+            $this->paymentIsntInterestFree();
+    }
 
     /**
      * The class is called for the two addresses (billing and shipping)
      * This prevents the method from adding the interest two times
+     *
+     * @param Mage_Sales_Model_Quote_Address $address
+     *
+     * @return PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount
      */
     public function collect(Mage_Sales_Model_Quote_Address $address)
     {
         parent::collect($address);
-        if (
-            $this->paymentMethodUsedWasPagarme($address) &&
-            $this->addressUsedIsShipping($address) &&
-            $this->wasCalledAfterPaymentMethodSelection() &&
-            $this->interestRateIsntZero() &&
-            $this->paymentIsntInterestFree()
-        ) {
-            $paymentMethodParameters = Mage::app()->getRequest()->getPost()['payment'];
+        if ($this->shouldCollect($address)) {
+            $paymentMethodParameters = Mage::app()
+                ->getRequest()
+                ->getPost()['payment'];
+
             $this->interestValue = $this->interestAmountInReals(
                 $address,
                 $paymentMethodParameters
@@ -33,32 +51,39 @@ class PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount
             $this->_addAmount($this->interestValue);
             $this->_addBaseAmount($this->interestValue);
 
-            $address->setGrandTotal($address->getGrandTotal() + $this->interestValue);
-            $address->setBaseGrandTotal($address->getBaseGrandTotal() + $this->interestValue);
+            $orderTotal = $address->getGrandTotal() + $this->interestValue;
+            $address->setGrandTotal($orderTotal);
+            $address->setBaseGrandTotal($orderTotal);
         }
 
         return $this;
     }
 
+    /**
+     * @param Mage_Sales_Model_Quote_Address $address
+     *
+     * @return PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount
+     */
     public function fetch(Mage_Sales_Model_Quote_Address $address)
     {
-        if (
-            $this->paymentMethodUsedWasPagarme($address) &&
-            $this->addressUsedIsShipping($address) &&
-            $this->wasCalledAfterPaymentMethodSelection() &&
-            $this->interestRateIsntZero() &&
-            $this->paymentIsntInterestFree()
-        ) {
-            $address->addTotal(array(
+        // @codingStandardsIgnoreLine
+        if ($this->shouldCollect($address)) {
+            $address->addTotal([
                 'code' => $this->getCode(),
                 'title' => __('Installments related Interest'),
                 'value' => $this->interestValue
-            ));
+            ]);
         }
 
         return $this;
     }
 
+    /**
+     * @param Mage_Sales_Model_Quote_Address $address
+     * @param array $paymentMethodParameters
+     *
+     * @return float
+     */
     private function interestAmountInReals($address, $paymentMethodParameters)
     {
         $pagarMeSdk = Mage::getModel('pagarme_core/sdk_adapter')
@@ -76,14 +101,21 @@ class PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount
             $choosedInstallments,
             $this->getFreeInstallmentStoreConfig(),
             $this->getInterestRateStoreConfig(),
-            $this->getMaxInstallmentStoreConfig()
+            $this->getMaxInstallmentStoreConfig(),
+            $pagarMeSdk
         );
 
+        // @codingStandardsIgnoreLine
         $interestAmountInCents = $installmentCalc->getTotal() - $totalAmountInCents;
 
         return $helper->parseAmountToFloat($interestAmountInCents);
     }
 
+    /**
+     * @param Mage_Sales_Model_Quote_Address $address
+     *
+     * @return bool
+     */
     private function paymentMethodUsedWasPagarme(
         Mage_Sales_Model_Quote_Address $address
     ) {
@@ -91,24 +123,41 @@ class PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount
         return $quote->getPayment()->getMethod() == 'pagarme_creditcard';
     }
 
+    /**
+     * @param Mage_Sales_Model_Quote_Address $address
+     *
+     * @return bool
+     */
     private function addressUsedIsShipping(
         Mage_Sales_Model_Quote_Address $address
     ) {
         return $address->getAddressType() == 'shipping';
     }
 
+    /**
+     * @return bool
+     */
     private function wasCalledAfterPaymentMethodSelection()
     {
         $paymentMethodParameters = Mage::app()->getRequest()->getPost();
+
+        // @codingStandardsIgnoreStart
         return array_key_exists('payment', $paymentMethodParameters)
             && array_key_exists('installments', $paymentMethodParameters['payment']);
+        // @codingStandardsIgnoreEnd
     }
 
+    /**
+     * @return bool
+     */
     private function interestRateIsntZero()
     {
         return $this->getFreeInstallmentStoreConfig() > 0;
     }
 
+    /**
+     * @return bool
+     */
     private function paymentIsntInterestFree()
     {
         $paymentMethodParameters = Mage::app()->getRequest()->getPost();

--- a/app/code/community/PagarMe/CreditCard/Model/Quote/Address/Total/CreditCardInterestAmount.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Quote/Address/Total/CreditCardInterestAmount.php
@@ -25,8 +25,6 @@ class PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount
             $this->paymentIsntInterestFree()
         ) {
             $paymentMethodParameters = Mage::app()->getRequest()->getPost()['payment'];
-            $address->setDiscountAmount(0);
-            $address->setBaseDiscountAmount(0);
             $this->interestValue = $this->interestAmountInReals(
                 Mage::getSingleton('checkout/session')->getQuote(),
                 $paymentMethodParameters
@@ -34,6 +32,9 @@ class PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount
 
             $this->_addAmount($this->interestValue);
             $this->_addBaseAmount($this->interestValue);
+
+            $address->setGrandTotal($address->getGrandTotal() + $this->interestValue);
+            $address->setBaseGrandTotal($address->getBaseGrandTotal() + $this->interestValue);
         }
 
         return $this;

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.14.3</version>
+            <version>3.14.4</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -17,6 +17,7 @@
             <quote>
                 <totals>
                     <pagarme_creditcard_interest>
+                        <after>grand_total</after>
                         <class>pagarme_creditcard/quote_address_total_creditCardInterestAmount</class>
                     </pagarme_creditcard_interest>
                 </totals>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.14.3</version>
+            <version>3.14.4</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/phpcsruleset.xml
+++ b/phpcsruleset.xml
@@ -76,7 +76,15 @@
   </rule>
   <!-- Validates that all parameters with default values are declared as last arguments -->
   <rule ref="PEAR.Functions.ValidDefaultValue"/>
-
+  <!-- Validates that multiline structures is indented correctly -->
+  <rule ref="PEAR.ControlStructures.MultiLineCondition">
+    <properties>
+        <property name="indent" value="4" />
+    </properties>
+  </rule>
+  <rule ref="PEAR.ControlStructures.MultiLineCondition">
+    <exclude name="PEAR.ControlStructures.MultiLineCondition.StartWithBoolean" />
+  </rule>
   <!-- Validates the docblock alignment -->
   <rule ref="Squiz.Commenting.DocCommentAlignment"/>
   <!-- Validates all docblock comments in a file -->
@@ -84,6 +92,7 @@
     <exclude name="Squiz.Commenting.FileComment.Missing"/>
     <exclude name="Generic.Commenting.DocComment.Empty"/>
   </rule>
+  <rule ref="Squiz.Commenting.VariableComment" />
   <!-- Check docblocks for missing @throws tags -->
   <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
   <!-- Blocks the usage of elseif -->

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -533,7 +533,7 @@ class CreditCardContext extends RawMinkContext
         )->getText();
         \PHPUnit_Framework_TestCase::assertEquals(
             $checkoutTotalAmount,
-            'R$27.44'
+            'R$32.44'
         );
     }
 
@@ -689,5 +689,36 @@ class CreditCardContext extends RawMinkContext
         } catch (Exception $exception) {
             throw $exception;
         }
+    }
+
+
+    /**
+     * @Then the checkout order review interest amount should be :interestAmount
+     */
+    public function theCheckoutOrderReviewInterestAmountShouldBe(
+        $interestAmount
+    ) {
+        $page = $this->session->getPage();
+
+        $interestAmountText = sprintf(
+            'Installments related Interest R$%s',
+            $interestAmount
+        );
+
+        $orderReviewElement = $page->find('named', array(
+            'content',
+            $interestAmountText
+        ));
+
+        if(is_null($orderReviewElement)) {
+            throw new Exception(
+                'Interest amount text should be present on page.'
+            );
+        }
+
+        PHPUnit_Framework_Assert::assertEquals(
+            $orderReviewElement->getText(),
+            $interestAmountText
+        );
     }
 }

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -691,7 +691,6 @@ class CreditCardContext extends RawMinkContext
         }
     }
 
-
     /**
      * @Then the checkout order review interest amount should be :interestAmount
      */

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -72,7 +72,8 @@ Feature: Credit Card
         And I choose 10
         And I confirm my payment information
         And place order
-        Then the purchase must be created with value based on both 10 and 10
+        Then the checkout order review interest amount should be "16.22"
+        And the purchase must be created with value based on both 10 and 10
 
     @order_view_interest @skipTest
     Scenario: Check the interest in the order details page

--- a/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_InstallmentsTest.php
+++ b/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_InstallmentsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use PagarMe\Sdk\PagarMe;
+
+class PagarMe_CreditCard_Model_InstallmentsTest extends PHPUnit_Framework_TestCase
+{
+    private function getSdkMock()
+    {
+        $sdkMock = $this->getMockBuilder('\PagarMe\Sdk\PagarMe')
+            ->disableOriginalConstructor()
+            ->setMethods([
+                'calculation',
+                'calculateInstallmentsAmount'
+            ])
+            ->getMock();
+
+        $sdkMock->expects($this->any())
+            ->method('calculation')
+            ->will($this->returnSelf());
+
+        return $sdkMock;
+    }
+
+    public function testCalculateInstallmentsWithInterestRate() {
+        $amount = 100;
+        $installments = 2;
+        $freeInstallments = 0;
+        $interestRate = 10;
+        $maxInstallments = 2;
+
+        $sdkMock = $this->getSdkMock();
+
+        $sdkMock->expects($this->any())
+            ->method('calculateInstallmentsAmount')
+            ->with(
+                $this->equalTo($amount),
+                $this->equalTo($interestRate),
+                $this->equalTo($freeInstallments),
+                $this->equalTo($maxInstallments)
+            )
+            ->willReturn([
+                '1' => [
+                    'installment_amount' => 55,
+                    'total_amount' => 110
+                ],
+                '2' => [
+                    'installment_amount' => 60,
+                    'total_amount' => 120
+                ]
+            ]);
+
+        $installmentsCalc = new PagarMe_CreditCard_Model_Installments(
+            $amount,
+            $installments,
+            $freeInstallments,
+            $interestRate,
+            $maxInstallments,
+            $sdkMock
+        );
+
+        $this->assertEquals(120, $installmentsCalc->getTotal());
+    }
+}


### PR DESCRIPTION
### Descrição

Corrige o cálculo de juros aplicando a seguinte fórmula:

**Valor do pedido** = valor total dos produtos + valor do frete - descontos

E então, com o **Valor do pedido** em mãos, o juros é aplicado sobre ele.

Nesta correção, a exibição de juros na select box de parcelamento é afetada, além do valor total durante a etapa revisão do pedido no _checkout_.

### Número da Issue

#329 

### Testes Realizados

Testes unitários e de aceitação.