### PR TITLE
Cartão de crédito: adicionar valor mínimo de parcelas.

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.14.5</version>
+            <version>3.14.6</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/Model/CurrentOrder.php
+++ b/app/code/community/PagarMe/Core/Model/CurrentOrder.php
@@ -7,6 +7,10 @@ class PagarMe_Core_Model_CurrentOrder
      * @var \Mage_Sales_Model_Quote
      */
     private $quote;
+
+    /**
+     * @var PagarMe_Core_Model_Sdk_Adapter $sdk
+     */
     private $pagarMeSdk;
 
     public function __construct(

--- a/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
+++ b/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
@@ -9,8 +9,7 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
      */
     public function isDeveloperModeEnabled()
     {
-        if (
-            Mage::getIsDeveloperMode() ||
+        if (Mage::getIsDeveloperMode() ||
             getenv('PAGARME_DEVELOPMENT') === 'enabled'
         ) {
             return true;
@@ -41,6 +40,9 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         return $devPostbackUrl;
     }
 
+    /**
+     * @return bool
+     */
     private function isTransparentCheckoutActiveStoreConfig()
     {
         return (bool) $this->getConfigurationWithName(
@@ -48,6 +50,9 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    /**
+     * @return string
+     */
     private function getCreditcardTitleStoreConfig()
     {
         return $this->getConfigurationWithName(
@@ -55,6 +60,9 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    /**
+     * @return int
+     */
     private function getMaxInstallmentStoreConfig()
     {
         return (int) $this->getConfigurationWithName(
@@ -62,6 +70,9 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    /**
+     * @return float
+     */
     private function getMinInstallmentValueStoreConfig()
     {
         return (float) $this->getConfigurationWithName(
@@ -69,6 +80,9 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    /**
+     * @return string
+     */
     public function getEncryptionKeyStoreConfig()
     {
         return $this->getConfigurationWithName(
@@ -76,6 +90,9 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    /**
+     * @return bool
+     */
     public function getAsyncTransactionConfig()
     {
         return $this->getConfigurationWithName(
@@ -83,6 +100,9 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    /**
+     * @return string
+     */
     public function getPaymentActionConfig()
     {
         return $this->getConfigurationWithName(
@@ -90,6 +110,9 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    /**
+     * @return int
+     */
     private function getFreeInstallmentStoreConfig()
     {
         return (int) $this->getConfigurationWithName(
@@ -97,6 +120,9 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    /**
+     * @return float
+     */
     private function getInterestRateStoreConfig()
     {
         return (float) $this->getConfigurationWithName(
@@ -104,6 +130,11 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
     private function getConfigurationWithName($name)
     {
         return Mage::getStoreConfig("payment/{$name}");

--- a/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
+++ b/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
@@ -62,6 +62,13 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
         );
     }
 
+    private function getMinInstallmentValueStoreConfig()
+    {
+        return (float) $this->getConfigurationWithName(
+            'pagarme_configurations/creditcard_min_installment_value'
+        );
+    }
+
     public function getEncryptionKeyStoreConfig()
     {
         return $this->getConfigurationWithName(

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.14.5</version>
+            <version>3.14.6</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/system.xml
+++ b/app/code/community/PagarMe/Core/etc/system.xml
@@ -103,11 +103,21 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </creditcard_interest_rate>
+                        <creditcard_min_installment_value translate="label comment">
+                            <label>Minimum Installment Value</label>
+                            <comment>Example 5.00</comment>
+                            <frontend_type>text</frontend_type>
+                            <frontend_class>validate-number</frontend_class>
+                            <sort_order>14</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </creditcard_min_installment_value>
                         <creditcard_free_installments translate="label">
                             <label>Free Installments</label>
                             <frontend_type>text</frontend_type>
                             <frontend_class>validate-number</frontend_class>
-                            <sort_order>14</sort_order>
+                            <sort_order>15</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
@@ -116,7 +126,7 @@
                             <label>Allowed Credit Card Brands</label>
                             <frontend_type>multiselect</frontend_type>
                             <source_model>pagarme_core/system_config_source_creditCardBrands</source_model>
-                            <sort_order>15</sort_order>
+                            <sort_order>16</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>

--- a/app/code/community/PagarMe/CreditCard/Block/Form/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Block/Form/Creditcard.php
@@ -15,6 +15,9 @@ class PagarMe_Creditcard_Block_Form_CreditCard extends Mage_Payment_Block_Form_C
         $this->setTemplate(self::TEMPLATE);
     }
 
+    /**
+     * @return array
+     */
     public function getInstallments()
     {
         $quote = Mage::helper('checkout')->getQuote();
@@ -24,11 +27,40 @@ class PagarMe_Creditcard_Block_Form_CreditCard extends Mage_Payment_Block_Form_C
             $pagarMeSdk
         );
 
+        $maxInstallments = $this->getMaxInstallmentsByMinimumAmount(
+            $currentOrder->productsTotalValueInBRL()
+        );
+
         return $currentOrder->calculateInstallments(
-            $this->getMaxInstallmentStoreConfig(),
+            $maxInstallments,
             $this->getFreeInstallmentStoreConfig(),
             $this->getInterestRateStoreConfig()
         );
     }
-}
 
+    /**
+     * @param float $orderTotal
+     *
+     * @return int
+     */
+    public function getMaxInstallmentsByMinimumAmount($orderTotal)
+    {
+        $minInstallmentAmount = $this->getMinInstallmentValueStoreConfig();
+
+        $maxInstallmentsConfig = $this->getMaxInstallmentStoreConfig();
+
+        if ($minInstallmentAmount <= 0) {
+            return $this->getMaxInstallmentStoreConfig();
+        }
+
+        $installmentsNumber = floor($orderTotal / $minInstallmentAmount);
+
+        $maxInstallments = $installmentsNumber ? $installmentsNumber : 1;
+
+        if ($maxInstallments > $this->getMaxInstallmentStoreConfig()) {
+            return $this->getMaxInstallmentStoreConfig();
+        }
+
+        return $maxInstallments;
+    }
+}

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.14.5</version>
+            <version>3.14.6</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.14.5</version>
+            <version>3.14.6</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "behat/mink-extension": "~2.2",
         "n98/magerun": "@stable"
     },
-    "archive":{
-        "exclude":[
+    "archive": {
+        "exclude": [
             ".coveralls.yml",
             ".behat.yml",
             ".travis.yml",
@@ -34,7 +34,8 @@
             "ISSUE-TEMPLATE.md",
             "CONTRUBUTING.md",
             "docker-compose.yml",
-            ".env"
+            ".env",
+            "tests/"
         ]
     }
 }

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -91,6 +91,25 @@ class CreditCardContext extends RawMinkContext
     }
 
     /**
+     * @AfterScenario
+     */
+    public function resetInstallmentsAndInterestConfiguration() {
+        $config = Mage::getModel('core/config');
+        $config->saveConfig(
+            'payment/pagarme_configurations/creditcard_max_installments',
+            12
+        );
+        $config->saveConfig(
+            'payment/pagarme_configurations/creditcard_interest_rate',
+            0
+        );
+        $config->saveConfig(
+            'payment/pagarme_configurations/creditcard_min_installment_value',
+            1
+        );
+    }
+
+    /**
      * @Given a registered user
      */
     public function aRegisteredUser()
@@ -207,6 +226,19 @@ class CreditCardContext extends RawMinkContext
         $config->saveConfig(
             'payment/pagarme_configurations/creditcard_max_installments',
             $maxInstallments
+        );
+    }
+
+    /**
+     * @When I set the minimum installment amount to :minInstallmentAmount
+     */
+    public function iSetMinInstallmentAmountTo($minInstallmentAmount)
+    {
+        $config = Mage::getModel('core/config');
+
+        $config->saveConfig(
+            'payment/pagarme_configurations/creditcard_min_installment_value',
+            $minInstallmentAmount
         );
     }
 

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -26,7 +26,6 @@ Feature: Credit Card
         | authorize_only    | yes     | pending_payment          |
         | authorize_capture | yes     | pending_payment          |
 
-    @refused
     Scenario: Make a sync refused order by credit card
         Given a registered user
         And the administrator set the async configuration to "no"
@@ -40,7 +39,6 @@ Feature: Credit Card
         And place order
         Then I must stay in the checkout page
 
-    @refused
     Scenario: Make an async refused order by credit card
         Given a registered user
         And the administrator set the async configuration to "yes"
@@ -59,6 +57,7 @@ Feature: Credit Card
     Scenario Outline: Change the max installments configuration
         Given a registered user
         When I set max installments to "<max_installments>"
+        And I set the minimum installment amount to "<min_installment_amount>"
         And I access the store page
         And add any product to basket
         And I go to checkout page
@@ -66,16 +65,14 @@ Feature: Credit Card
         And confirm billing and shipping address information
         And choose pay with transparent checkout using credit card
         And I confirm my payment information
-        And I should see only installment options up to "<max_installments>"
+        And I should see only installment options up to "<desired_max_installment>"
         And place order
         Then the purchase must be paid with success
         Examples:
-        | max_installments  |
-        | 12                |
-        | 3                 |
-        | 1                 |
+        | max_installments  | min_installment_amount | desired_max_installment |
+        | 12                | 1                      | 12                      |
+        | 5                 | 4.99                   | 3                       |
 
-    @only
     Scenario: Make a purchase by credit card with interest and installments
         Given a registered user
         When I set max installments to 10


### PR DESCRIPTION
### Descrição

Atualmente o lojista não pode configurar o valor mínimo por parcela. Com este PR o lojista poderá escolher o valor mínimo por parcela.

Por exemplo, se ele configurar o valor mínimo por parcela para R$5, em uma compra de R$15, a compra só poderá ser parcelada em até 3x.

### Número da Issue

Sem Issue

### Testes Realizados

Testes manuais e de aceitação