### PR TITLE
Informa user-agent em header customizado

### DIFF
--- a/app/code/community/PagarMe/Core/Model/Sdk/Adapter.php
+++ b/app/code/community/PagarMe/Core/Model/Sdk/Adapter.php
@@ -18,8 +18,11 @@ class PagarMe_Core_Model_Sdk_Adapter extends Mage_Core_Model_Abstract
     {
         parent::_construct();
 
+        $apiKey = Mage::getStoreConfig(
+            'payment/pagarme_configurations/general_api_key'
+        );
         $this->pagarMeSdk = new \PagarMe\Sdk\PagarMe(
-            Mage::getStoreConfig('payment/pagarme_configurations/general_api_key'),
+            $apiKey,
             self::SDK_TIMEOUT,
             $this->getUserAgent()
         );
@@ -38,13 +41,16 @@ class PagarMe_Core_Model_Sdk_Adapter extends Mage_Core_Model_Abstract
      */
     public function getUserAgent()
     {
+        $userAgentValue = sprintf(
+            'Magento/%s PagarMe/%s PHP/%s',
+            Mage::getVersion(),
+            Mage::getConfig()->getNode()->modules->PagarMe_Core->version,
+            phpversion()
+        );
+
         return [
-            'User-Agent' => sprintf(
-                'Magento/%s PagarMe/%s PHP/%s',
-                Mage::getVersion(),
-                Mage::getConfig()->getNode()->modules->PagarMe_Core->version,
-                phpversion()
-            )
+            'User-Agent' => $userAgentValue,
+            'X-PagarMe-User-Agent' => $userAgentValue
         ];
     }
 }


### PR DESCRIPTION
### Descrição

O objetivo deste PR é adicionar aos requests um novo header `X-PagarMe-User-Agent`. Este header, é utilizado internamente para realizar trackeamento e identificar a aplicação de origem que realizou um request para criar uma transação.

### Número da Issue

Não há

### Testes Realizados

Testes manuais utilizando chaves api de testes.