### PR TITLE
Estorno: Corrige valor exibido no estorno de um pedido

### DIFF
--- a/app/code/community/PagarMe/CreditCard/Model/CreditmemoTotals.php
+++ b/app/code/community/PagarMe/CreditCard/Model/CreditmemoTotals.php
@@ -3,6 +3,11 @@
 class PagarMe_CreditCard_Model_CreditmemoTotals extends  Mage_Sales_Model_Order_Creditmemo_Total_Abstract
 {
 
+    /**
+     * @param Mage_Sales_Model_Order_Creditmemo $creditmemo
+     *
+     * @return PagarMe_CreditCard_Model_CreditmemoTotals
+     */
     public function collect(Mage_Sales_Model_Order_Creditmemo $creditmemo)
     {
         $order = $creditmemo->getOrder();
@@ -10,10 +15,13 @@ class PagarMe_CreditCard_Model_CreditmemoTotals extends  Mage_Sales_Model_Order_
             ->getTransactionByOrderId(
                 $order->getId()
             );
-        $creditmemo->setGrandTotal($transaction->getRateAmount());
-        $creditmemo->setBaseGrandTotal($transaction->getRateAmount());
+        $creditmemo->setGrandTotal(
+            $creditmemo->getGrandTotal() + $transaction->getRateAmount()
+        );
+        $creditmemo->setBaseGrandTotal(
+            $creditmemo->getBaseGrandTotal() + $transaction->getRateAmount()
+        );
 
         return $this;
     }
-
 }

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -624,6 +624,24 @@ class CreditCardContext extends RawMinkContext
     }
 
     /**
+     * @When I check the creditmemo totals in its admin detail page
+     */
+    public function iCheckTheCreditmemoTotalsInItsAdminDetailPage()
+    {
+        $orderObject = Mage::getModel('sales/order')->load($this->orderId);
+
+        $invoiceIds = $orderObject->getInvoiceCollection()->getAllIds();
+
+        Mage::getConfig()->saveConfig('admin/security/use_form_key', 0);
+
+        $url = $this->magentoUrl . 'index.php/admin/sales_order_creditmemo/new/order_id/'.$this->orderId.'invoice_id/'.$invoiceIds[0];
+
+        $this->session->visit($url);
+
+        Mage::getConfig()->saveConfig('admin/security/use_form_key', 1);
+    }
+
+    /**
      * @Then the interest value should be :interest in the invoice details
      */
     public function theInterestValueShouldBeInTheInvoiceDetails($interest)
@@ -637,6 +655,30 @@ class CreditCardContext extends RawMinkContext
             );
 
         \PHPUnit_Framework_TestCase::assertEquals('R$'.$interest, $invoiceInterest);
+    }
+
+    /**
+     * @Then the interest value and grand total must be correct
+     */
+    public function theInterestValueAndGrantTotalMustBeCorrect()
+    {
+        $this->session->wait(3000);
+
+        $creditMemoInterest = $this->session->evaluateScript(
+            "return document.querySelector(
+                '.order-totals tr:last-child > td:last-child > .price'
+            ).innerHTML;"
+        );
+
+        \PHPUnit_Framework_TestCase::assertEquals('R$16.22', $creditMemoInterest);
+
+        $grandTotal = $this->session->evaluateScript(
+            "return document.querySelector(
+                '.order-totals tfoot > tr > td:last-child .price'
+            ).innerHTML;"
+        );
+
+        \PHPUnit_Framework_TestCase::assertEquals('R$32.44', $grandTotal);
     }
 
     /**

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -649,10 +649,10 @@ class CreditCardContext extends RawMinkContext
         $this->session->wait(3000);
 
         $invoiceInterest = $this->session->evaluateScript(
-                "return document.querySelector(
-                    '.order-totals td:last-child > .price'
-                ).innerHTML;"
-            );
+            "return document.querySelector(
+                '.order-totals tr:last-child > td:last-child > .price'
+            ).innerHTML;"
+        );
 
         \PHPUnit_Framework_TestCase::assertEquals('R$'.$interest, $invoiceInterest);
     }

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -149,7 +149,7 @@ Feature: Credit Card
         Given a existing order
         When I login to the admin
         And I check the invoice interest amount in its admin detail page
-        Then the interest value should be "11.22" in the invoice details
+        Then the interest value should be "16.22" in the invoice details
 
     Scenario: Check if in an existing order's creditmemo totals is correct
         Given a existing order

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -151,6 +151,12 @@ Feature: Credit Card
         And I check the invoice interest amount in its admin detail page
         Then the interest value should be "11.22" in the invoice details
 
+    Scenario: Check if in an existing order's creditmemo totals is correct
+        Given a existing order
+        When I login to the admin
+        And I check the creditmemo totals in its admin detail page
+        Then the interest value and grand total must be correct
+
     @capture_online @skipTest
     Scenario: Capture a purchase by credit card through the platform
         Given a created order authorized only


### PR DESCRIPTION
### Descrição

Corrige incompatibilidade entre o módulo do branch master e o v2 quando o estorno é realizado.

Quando ambos módulos estão instalados, a tela de estorno exibe como `grand total` o valor da taxa de juros, quando o correto é exibir o `valor da taxa de juros + (valor dos produtos + frete)`.

### Número da Issue

#350 

### Testes Realizados

Testes manuais, com ambos os módulos instalados.
Testes de aceitação, para garantir que continue funcionando com apenas o v2 instalado.