### PR TITLE
Correção: Exibe pedidos pendentes para o comprador

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -21,6 +21,15 @@
                 <class>PagarMe_Boleto_Helper</class>
             </pagarme_boleto>
         </helpers>
+        <sales>
+            <order>
+                <states>
+                    <pending_payment translate="label">
+                        <visible_on_front>1</visible_on_front>
+                    </pending_payment>
+                </states>
+            </order>
+        </sales>
     </global>
     <frontend>
         <layout>


### PR DESCRIPTION
### Descrição

A configuração padrão do magento é de não exibir pedidos pendentes para os compradores.

Porém, caso um cliente faça um pedido escolhendo como meio de pagamento boleto bancário, o primeiro status desse pedido será pendente. O que fará com que o comprador não consiga visualizar o pedido dele no histórico de pedidos.

Esse PR adiciona pedidos pendentes ao histório de pedidos

### Número da Issue

#354 

### Testes Realizados

Testes manuais, para garantir que os pedidos pendentes estão visíveis na tela de histórico de pedidos.