### PR TITLE
Ajusta workflow de logs para handler de cancelamento

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Módulo de integração Pagar.me para Magento 1.x
 * `Número de linhas em um endereço de rua` com valor `4`
 *  `Exibir Tax/Vat` com valor `Habilitado`
 7. Salve as configurações
+8. Vá em `Sistema > Configuração > Catálogo > Inventário > Opções de estoque`
+* Altere a opção `Reajustar Estoque Quando Pedidor for Cancelado` para `Sim`
 
 ### Configuração de cancelamento automático de boletos não pagos
 

--- a/app/code/community/PagarMe/Core/Model/OrderStatusHandler/Canceled.php
+++ b/app/code/community/PagarMe/Core/Model/OrderStatusHandler/Canceled.php
@@ -53,19 +53,30 @@ class PagarMe_Core_Model_OrderStatusHandler_Canceled extends BaseHandler
             'core/resource_transaction'
         );
 
-        $this->cancel();
+        try {
+            $this->cancel();
+            $magentoTransaction->addObject($this->order)->save();
 
-        $magentoTransaction->addObject($this->order)->save();
+            $logMessage = sprintf(
+                'Order %s, transaction %s updated to %s',
+                $this->order->getId(),
+                $this->transaction->getId(),
+                Mage_Sales_Model_Order::STATE_CANCELED
+            );
+            
+            Mage::log($logMessage);
+        } catch (\Exception $exception) {
+            $logExceptionMessage = sprintf(
+                'Tried to update order %s, transaction %s updated to %s but failed. %s',
+                $this->order->getId(),
+                $this->transaction->getId(),
+                Mage_Sales_Model_Order::STATE_CANCELED,
+                $exception->getMessage()
+            );
 
-        $logMessage = sprintf(
-            'Order %s, transaction %s updated to %s',
-            $this->order->getId(),
-            $this->transaction->getId(),
-            Mage_Sales_Model_Order::STATE_CANCELED
-        );
-
-        Mage::log($logMessage);
-
+            Mage::logException($logExceptionMessage);
+        }
+        
         return $this->order;
     }
 }


### PR DESCRIPTION
### Descrição

Até então, sempre que o handler de cancelamento era executado, uma entrada no arquivo de log era criada independente se o cancelamento fosse efetuado com sucesso. Esse PR ajusta isso envolvendo o fluxo de cancelamento em um bloco `try/catch` e, em caso de falha, cria uma nova entrada nos logs de exception.

Adiciona também uma instrução no README relacionada às configurações do módulo no que diz respeito ao gerenciamento de estoque.

### Número da Issue

Nenhuma issue relacionada

### Testes Realizados

Nenhum teste adicionado.