### PR TITLE
Cartão de crédito: adiciona a opção de estorno parcial

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Boleto>
-            <version>3.14.7</version>
+            <version>3.15.0</version>
         </PagarMe_Boleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.14.7</version>
+            <version>3.15.0</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -61,6 +61,11 @@ class PagarMe_CreditCard_Model_Creditcard extends PagarMe_Core_Model_AbstractPay
     /**
      * @var boolean
      */
+    protected $_canRefundInvoicePartial = true;
+
+    /**
+     * @var boolean
+     */
     protected $_canUseForMultishipping = true;
 
     /**
@@ -792,13 +797,13 @@ class PagarMe_CreditCard_Model_Creditcard extends PagarMe_Core_Model_AbstractPay
             );
         }
 
-        $amount = ((float)$invoice->getGrandTotal()) * 100;
+        $amount = Mage::helper('pagarme_core')
+            ->parseAmountToCents($amount);
 
         try {
             $this->transaction = $this->sdk
                 ->transaction()
                 ->get($invoice->getTransactionId());
-
 
             $this->sdk
                 ->transaction()

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.14.7</version>
+            <version>3.15.0</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.14.7</version>
+            <version>3.15.0</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -3,7 +3,6 @@ Feature: Credit Card
     I want to use the transparent checkout for credit card purchases with installments
     So that the clients on my store can buy their goods without knowing that the payment is resolved by Pagar.me
 
-
     Scenario Outline: Make a purchase by credit card
         Given a registered user
         And the administrator set payment action to "<payment_action>"
@@ -169,10 +168,20 @@ Feature: Credit Card
         Then the order should be captured on Pagar.me
 
     Scenario: Capture partially a purchase by credit card through the platform
-        Given an order with more than one product
+        Given an "pending_payment" order with more than one product
         When I login to the admin
-        Then I must capture the invoice partially
-        When select to capture amount "online"
+        And I go to the new invoice page
+        And I set the product quantity to "3"
+        And select to capture amount "online"
         And click on the submit invoice button
-        Then the order should be captured on Pagar.me
-        And the order must be captured partially on Pagar.me
+        Then the order should be "captured" on Pagar.me
+        And the order must be "captured" partially on Pagar.me
+
+    Scenario: Refund partially a purchase by credit card through the platform
+        Given an "processing" order with more than one product
+        When I login to the admin
+        And I go to the invoice credit memo page
+        And I set the product quantity to "1"
+        And click on the refund button
+        Then the order should be "refunded" on Pagar.me
+        And the order must be "refunded" partially on Pagar.me


### PR DESCRIPTION
### Descrição

Com essa funcionalidade, o lojista pode estornar o pedido parcialmente.

Pode ser útil em situações onde o cliente compra mais de um produto, e um vem com defeito, ou ele deseja devolver um deles. Então, invés de estornar o pedido todo, o lojista pode simplesmente estornar apenas o valor do produto que será devolvido.

### Número da Issue

#351

### Testes Realizados

Testes manuais.
Testes de aceitação. 