### PR TITLE
Compatibilidade com o frontend dos boletos

### DIFF
--- a/app/code/community/PagarMe/Boleto/etc/config.xml
+++ b/app/code/community/PagarMe/Boleto/etc/config.xml
@@ -37,6 +37,9 @@
                 <pagarme_boleto>
                     <file>pagarme/pagarme_boleto.xml</file>
                 </pagarme_boleto>
+                <pagarme>
+                	<file></file>
+                </pagarme>
             </updates>
         </layout>
     </frontend>


### PR DESCRIPTION
### Descrição

Para quem tem o módulo master (0.1.x) instalado, a tela de sucesso dos pedidos via boleto exibe dois botões de impressão. O primeiro deles direciona para uma página em branco.

Além disso o módulo antigo carrega CSS e JS desnecessários no checkout.

Esse ajuste remove qualquer alteração do frontend por parte do módulo antigo (v0.1.x).