### PR TITLE
Corrige conflito entre os módulos de boleto (v3.x e v.0.1.x)

### DIFF
--- a/app/code/community/PagarMe/Boleto/Helper/Data.php
+++ b/app/code/community/PagarMe/Boleto/Helper/Data.php
@@ -1,5 +1,0 @@
-<?php
-
-class PagarMe_Boleto_Helper_Data extends Mage_Core_Helper_Abstract
-{
-}

--- a/app/code/community/PagarMe/Bowleto/Block/Form/Boleto.php
+++ b/app/code/community/PagarMe/Bowleto/Block/Form/Boleto.php
@@ -1,5 +1,5 @@
 <?php
-class PagarMe_Boleto_Block_Form_Boleto extends Mage_Payment_Block_Form
+class PagarMe_Bowleto_Block_Form_Boleto extends Mage_Payment_Block_Form
 {
     const TEMPLATE = 'pagarme/form/boleto.phtml';
     

--- a/app/code/community/PagarMe/Bowleto/Block/Info/Boleto.php
+++ b/app/code/community/PagarMe/Bowleto/Block/Info/Boleto.php
@@ -1,6 +1,6 @@
 <?php
 
-class PagarMe_Boleto_Block_Info_Boleto extends Mage_Payment_Block_Info
+class PagarMe_Bowleto_Block_Info_Boleto extends Mage_Payment_Block_Info
 {
     use PagarMe_Core_Block_Info_Trait;
 
@@ -12,7 +12,7 @@ class PagarMe_Boleto_Block_Info_Boleto extends Mage_Payment_Block_Info
         $this->setTemplate(
             'pagarme/boleto/order_info/payment_details.phtml'
         );
-        $this->helper = Mage::helper('pagarme_boleto');
+        $this->helper = Mage::helper('pagarme_bowleto');
     }
 
     /**

--- a/app/code/community/PagarMe/Bowleto/Block/Success.php
+++ b/app/code/community/PagarMe/Bowleto/Block/Success.php
@@ -1,6 +1,6 @@
 <?php
 
-class PagarMe_Boleto_Block_Success extends Mage_Checkout_Block_Onepage_Success
+class PagarMe_Bowleto_Block_Success extends Mage_Checkout_Block_Onepage_Success
 {
     /**
      * @var Mage_Sales_Model_Order
@@ -32,7 +32,8 @@ class PagarMe_Boleto_Block_Success extends Mage_Checkout_Block_Onepage_Success
         if(array_key_exists('pagarme_payment_method', $additionalInfo)) {
             $paymentMethod = $additionalInfo['pagarme_payment_method'];
         }
-        if ($paymentMethod === PagarMe_Boleto_Model_Boleto::PAGARME_BOLETO) {
+
+        if ($paymentMethod === PagarMe_Bowleto_Model_Boleto::PAGARME_BOLETO) {
             return true;
         }
         return false;

--- a/app/code/community/PagarMe/Bowleto/Helper/Data.php
+++ b/app/code/community/PagarMe/Bowleto/Helper/Data.php
@@ -1,0 +1,5 @@
+<?php
+
+class PagarMe_Bowleto_Helper_Data extends Mage_Core_Helper_Abstract
+{
+}

--- a/app/code/community/PagarMe/Bowleto/Model/Boleto.php
+++ b/app/code/community/PagarMe/Bowleto/Model/Boleto.php
@@ -1,11 +1,11 @@
 <?php
 use \PagarMe\Sdk\PagarMe as PagarMeSdk;
 
-class PagarMe_Boleto_Model_Boleto extends PagarMe_Core_Model_AbstractPaymentMethod
+class PagarMe_Bowleto_Model_Boleto extends PagarMe_Core_Model_AbstractPaymentMethod
 {
-    protected $_code = 'pagarme_boleto';
-    protected $_formBlockType = 'pagarme_boleto/form_boleto';
-    protected $_infoBlockType = 'pagarme_boleto/info_boleto';
+    protected $_code = 'pagarme_bowleto';
+    protected $_formBlockType = 'pagarme_bowleto/form_boleto';
+    protected $_infoBlockType = 'pagarme_bowleto/info_boleto';
     protected $_isGateway = true;
     protected $_canAuthorize = true;
     protected $_canCapture = true;
@@ -14,7 +14,7 @@ class PagarMe_Boleto_Model_Boleto extends PagarMe_Core_Model_AbstractPaymentMeth
     protected $_canManageRecurringProfiles = true;
     protected $_isInitializeNeeded = true;
 
-    const PAGARME_BOLETO = 'pagarme_boleto';
+    const PAGARME_BOLETO = 'pagarme_bowleto';
     const POSTBACK_ENDPOINT = 'transaction_boleto';
 
     /**
@@ -54,8 +54,12 @@ class PagarMe_Boleto_Model_Boleto extends PagarMe_Core_Model_AbstractPaymentMeth
 
         $payment = $this->getInfoInstance();
 
-        $this->stateObject->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
-        $this->stateObject->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $this->stateObject->setState(
+            Mage_Sales_Model_Order::STATE_PENDING_PAYMENT
+        );
+        $this->stateObject->setStatus(
+            Mage_Sales_Model_Order::STATE_PENDING_PAYMENT
+        );
         $this->stateObject->setIsNotified(true);
 
         $this->authorize(

--- a/app/code/community/PagarMe/Bowleto/Model/UnpaidBoleto.php
+++ b/app/code/community/PagarMe/Bowleto/Model/UnpaidBoleto.php
@@ -2,7 +2,7 @@
 
 use \PagarMe\Sdk\Transaction\BoletoTransaction;
 
-class PagarMe_Boleto_Model_UnpaidBoleto
+class PagarMe_Bowleto_Model_UnpaidBoleto
 {
     /**
      * Returns configured timezone on platform

--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.15.0</version>
+            <version>3.15.1</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0"?>
 <config>
     <modules>
-        <PagarMe_Boleto>
+        <PagarMe_Bowleto>
             <version>3.15.0</version>
-        </PagarMe_Boleto>
+        </PagarMe_Bowleto>
     </modules>
     <global>
         <models>
-            <pagarme_boleto>
-                <class>PagarMe_Boleto_Model</class>
-            </pagarme_boleto>
+            <pagarme_bowleto>
+                <class>PagarMe_Bowleto_Model</class>
+            </pagarme_bowleto>
         </models>
         <blocks>
-            <pagarme_boleto>
-                <class>PagarMe_Boleto_Block</class>
-            </pagarme_boleto>
+            <pagarme_bowleto>
+                <class>PagarMe_Bowleto_Block</class>
+            </pagarme_bowleto>
         </blocks>
         <helpers>
-            <pagarme_boleto>
-                <class>PagarMe_Boleto_Helper</class>
-            </pagarme_boleto>
+            <pagarme_bowleto>
+                <class>PagarMe_Bowleto_Helper</class>
+            </pagarme_bowleto>
         </helpers>
         <sales>
             <order>
@@ -34,31 +34,31 @@
     <frontend>
         <layout>
             <updates>
-                <pagarme_boleto>
+                <pagarme_bowleto>
                     <file>pagarme/pagarme_boleto.xml</file>
-                </pagarme_boleto>
+                </pagarme_bowleto>
             </updates>
         </layout>
     </frontend>
     <frontend>
         <translate>
             <modules>
-                <PagarMe_Boleto>
+                <PagarMe_Bowleto>
                     <files>
                         <default>PagarMe_Boleto.csv</default>
                     </files>
-                </PagarMe_Boleto>
+                </PagarMe_Bowleto>
             </modules>
         </translate>
     </frontend>
     <admin>
         <translate>
             <modules>
-                <PagarMe_Boleto>
+                <PagarMe_Bowleto>
                     <files>
                         <default>PagarMe_Boleto.csv</default>
                     </files>
-                </PagarMe_Boleto>
+                </PagarMe_Bowleto>
             </modules>
         </translate>
     </admin>
@@ -67,21 +67,9 @@
             <cancel_boleto_unpaid_orders>
                 <schedule><cron_expr>1/1 * * * * </cron_expr></schedule>
                 <run>
-                    <model>pagarme_boleto/UnpaidBoleto::cancel</model>
+                    <model>pagarme_bowleto/UnpaidBoleto::cancel</model>
                 </run>
             </cancel_boleto_unpaid_orders>
         </jobs>
     </crontab>
-    <default>
-        <payment>
-            <pagarme_boleto>
-                <active>1</active>
-                <model>pagarme_boleto/boleto</model>
-                <title>Boleto</title>
-                <order_status>authorize</order_status>
-                <allow_specific>0</allow_specific>
-                <sort_order>1</sort_order>
-            </pagarme_boleto>
-        </payment>
-    </default>
 </config>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.15.0</version>
+            <version>3.15.1</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -106,14 +106,14 @@
                 <payment_methods>credit_card</payment_methods>
                 <payment_action>authorize</payment_action>
             </pagarme_creditcard>
-            <pagarme_boleto>
+            <pagarme_bowleto>
                 <active>1</active>
-                <model>pagarme_boleto/boleto</model>
+                <model>pagarme_bowleto/boleto</model>
                 <order_status>authorize</order_status>
                 <allowspecific>0</allowspecific>
                 <payment_methods>boleto</payment_methods>
                 <payment_action>authorize</payment_action>
-            </pagarme_boleto>
+            </pagarme_bowleto>
             <pagarme_configurations>
                 <modal_title>Pagarme Checkout</modal_title>
                 <modal_button_text>Realizar pagamento</modal_button_text>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.15.0</version>
+            <version>3.15.1</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.15.0</version>
+            <version>3.15.1</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/design/adminhtml/default/default/template/pagarme/boleto/order_info/payment_details.phtml
+++ b/app/design/adminhtml/default/default/template/pagarme/boleto/order_info/payment_details.phtml
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see PagarMe_Boleto_Block_Info_Boleto
+ * @see PagarMe_Bowleto_Block_Info_Boleto
  */
-$helper = Mage::helper('pagarme_boleto');
+$helper = Mage::helper('pagarme_bowleto');
 ?>
 <h3><?php echo $helper->__('Pagar.me Boleto'); ?></h3>
 <table id="pagarme_order_info_payment_details">

--- a/app/design/frontend/base/default/layout/pagarme/pagarme_boleto.xml
+++ b/app/design/frontend/base/default/layout/pagarme/pagarme_boleto.xml
@@ -9,7 +9,7 @@
     </default>
    <checkout_onepage_success>
         <reference name="content">
-          <block type="pagarme_boleto/success" name="pagarme_boleto.success" template="pagarme/boleto/success.phtml"/>
+          <block type="pagarme_bowleto/success" name="pagarme_bowleto.success" template="pagarme/boleto/success.phtml"/>
         </reference>
     </checkout_onepage_success>   
 </layout>

--- a/app/design/frontend/base/default/template/pagarme/boleto/order_info/payment_details.phtml
+++ b/app/design/frontend/base/default/template/pagarme/boleto/order_info/payment_details.phtml
@@ -2,7 +2,7 @@
 /**
  * @see PagarMe_Boleto_Block_Info_Boleto
  */
-$helper = Mage::helper('pagarme_boleto');
+$helper = Mage::helper('pagarme_bowleto');
 ?>
 <table id="pagarme_order_info_payment_details">
     <tr>

--- a/app/design/frontend/base/default/template/pagarme/boleto/success.phtml
+++ b/app/design/frontend/base/default/template/pagarme/boleto/success.phtml
@@ -1,13 +1,14 @@
 <?php
-
-if ($this->isBoletoPayment()):
-?>    
-<p class="pagarme_boleto_info_boleto">
-<?php echo Mage::helper('pagarme_boleto')->__('Click the followed link to print your boleto') ?> 
-    <a target="_blank" href="<?php echo $this->getBoletoUrl(); ?>">
-        <?php echo Mage::helper('pagarme_boleto')->__('click here') ?>
-    </a>
-</p>
-<?php 
-endif;
+/**
+ * @see PagarMe_Bowleto_Block_Success
+ */
 ?>
+
+<?php if ($this->isBoletoPayment()): ?>
+    <p class="pagarme_boleto_info_boleto">
+    <?php echo Mage::helper('pagarme_bowleto')->__('Click the followed link to print your boleto') ?> 
+        <a target="_blank" href="<?php echo $this->getBoletoUrl(); ?>">
+            <?php echo Mage::helper('pagarme_bowleto')->__('click here') ?>
+        </a>
+    </p>
+<?php endif; ?>

--- a/app/etc/modules/PagarMe_Bowleto.xml
+++ b/app/etc/modules/PagarMe_Bowleto.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <config>
     <modules>
-        <PagarMe_Boleto>
+        <PagarMe_Bowleto>
             <active>true</active>
             <codePool>community</codePool>
             <depends>
                 <PagarMe_Core />
             </depends>
-        </PagarMe_Boleto>
+        </PagarMe_Bowleto>
     </modules>
 </config>

--- a/tests/acceptance/BoletoAdminContext.php
+++ b/tests/acceptance/BoletoAdminContext.php
@@ -146,7 +146,7 @@ class BoletoAdminContext extends RawMinkContext
 
         $this->getSession()->wait(3500);
 
-        $this->page->find('css', '#p_method_pagarme_boleto')->click();
+        $this->page->find('css', '#p_method_pagarme_bowleto')->click();
     }
 
     /**

--- a/tests/acceptance/BoletoContext.php
+++ b/tests/acceptance/BoletoContext.php
@@ -102,8 +102,8 @@ class BoletoContext extends PagarMeMagentoContext
     public function choosePayWithTransparentCheckoutUsingBoleto()
     {
         $page = $this->session->getPage();
-        $this->waitForElement('#checkout-step-payment', 5000);
-        $page->find('css', '#p_method_pagarme_boleto')->click();
+        $this->waitForElement('#checkout-step-payment', 5500);
+        $page->find('css', '#p_method_pagarme_bowleto')->click();
     }
     /**
      * @When I confirm my payment information
@@ -124,16 +124,16 @@ class BoletoContext extends PagarMeMagentoContext
         $this->session
             ->getPage()
             ->pressButton(
-                Mage::helper('pagarme_boleto')
+                Mage::helper('pagarme_bowleto')
                 ->__('Place Order')
             );
+        $this->session->wait(15000);
     }
     /**
      * @Then the purchase must be placed with success
      */
     public function thePurchaseMustBePlacedWithSuccess()
     {
-        $this->session->wait(5000);
         $page = $this->session->getPage();
         $successMessage = $page->find('css', 'h1')
             ->getText();
@@ -144,7 +144,7 @@ class BoletoContext extends PagarMeMagentoContext
         \PHPUnit_Framework_TestCase::assertEquals(
             strtolower(
                 Mage::helper(
-                    'pagarme_boleto'
+                    'pagarme_bowleto'
                 )->__('Your order has been received.')
             ),
             strtolower($successMessage)
@@ -165,7 +165,7 @@ class BoletoContext extends PagarMeMagentoContext
     {
         $page = $this->session->getPage();
         \PHPUnit_Framework_TestCase::assertContains(
-            Mage::helper('pagarme_boleto')->__('Click the followed link to print your boleto'),
+            Mage::helper('pagarme_bowleto')->__('Click the followed link to print your boleto'),
             $page->find(
                 'css',
                 '.pagarme_boleto_info_boleto'
@@ -223,7 +223,7 @@ class BoletoContext extends PagarMeMagentoContext
      * @Then cancel orders with expired boletos by cron job model
      */
     public function cancelOrdersWithExpiredBoletosByCronJobModel() {
-        $unpaidBoletos = new PagarMe_Boleto_Model_UnpaidBoleto();
+        $unpaidBoletos = new PagarMe_Bowleto_Model_UnpaidBoleto();
 
         $unpaidBoletos->cancel();
     }

--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -357,7 +357,7 @@ class CheckoutContext extends RawMinkContext
         $page = $this->session->getPage();
         $helper = Mage::helper('pagarme_modal');
         \PHPUnit_Framework_TestCase::assertContains(
-            Mage::helper('pagarme_boleto')->__('Click the followed link to print your boleto'),
+            Mage::helper('pagarme_bowleto')->__('Click the followed link to print your boleto'),
             $page->find(
                 'css',
                 '.pagarme_boleto_info_boleto'


### PR DESCRIPTION
### Descrição

Os módulos de boleto de ambas as versões utilizavam o mesmo _code_ em arquivos de configuração e paths. Esse PR altera o nome utilizado de modo que não haja mais conflitos entre as duas versões e que seja possível utilizar os dois módulos ao mesmo tempo.

### Testes Realizados

Nenhum novo teste adicionado.