### PR TITLE
boleto: change delay to cancel unpaid boletos from 4 days to 7 days

### DIFF
--- a/app/code/community/PagarMe/Bowleto/Model/UnpaidBoleto.php
+++ b/app/code/community/PagarMe/Bowleto/Model/UnpaidBoleto.php
@@ -25,7 +25,7 @@ class PagarMe_Bowleto_Model_UnpaidBoleto
             'now',
             new DateTimeZone($this->getCurrentTimezone())
         );
-        $expiredBoletos = $today->modify('-4 days');
+        $expiredBoletos = $today->modify('-7 days');
 
         $boletosFilter = Mage::getModel('pagarme_core/transaction')
             ->getCollection();

--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.15.1</version>
+            <version>3.15.2</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.15.1</version>
+            <version>3.15.2</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.15.1</version>
+            <version>3.15.2</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.15.1</version>
+            <version>3.15.2</version>
         </PagarMe_Modal>
     </modules>
     <global>


### PR DESCRIPTION
### Descrição

Legenda:
~~dias sem conciliação~~
**dias de conciliação**

Este PR faz com que os boletos sejam cancelados 7 dias após a data de vencimento.

Chegamos à este número pois, caso o feriado caia em uma sexta-feira e seja a mesma data de expiração do boleto, o próximo dia de conciliação será terça feira.

O que nos resulta no seguinte:
~~Sexta (0)~~ - Data de expiração - O boleto pode ser pago nesse dia.
~~Sábado(1)~~
~~Domingo(2)~~
~~Segunda-feira(3)~~
**Terça-feira(4)** - Primeiro dia de conciliação
**Quarta-feira(5)**
**Quinta-feira(6)**
**Sexta-feira(7)**

Ou seja, o ideal é que o boleto só seja cancelado na Quarta feira(5), que é o segundo dia de conciliação de boleto

Porém, existem casos de pagamentos em feriados prolongados, por exemplo um feriado que caia em uma terça, ou quinta. No exemplo abaixo usaremos a terça feira.

Se o boleto for emitido para vencimento na sexta-feira, anterior à terça-feira que é feriado, as conciliações ficarão assim:

**Sexta (0)** - Data de expiração - O boleto pode ser pago nesse dia
~~Sábado(1)~~
~~Domingo(2)~~
~~Segunda-feira(3)~~
~~Terça-feira(4)~~ - Feriado
**Quarta-feira(5)** - Primeiro dia de conciliação
**Quinta-feira(6)**
**Sexta-feira(7)**

Ou seja, ainda haverão dias de conciliação antes de o pedido ser cancelado, evitando cancelamentos indevidos de pedido.

### Número da Issue

#368 