### PR TITLE
Corrige a data de expiração de boletos para dias úteis

### DIFF
--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.15.2</version>
+            <version>3.16.0</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/Helper/BusinessCalendar.php
+++ b/app/code/community/PagarMe/Core/Helper/BusinessCalendar.php
@@ -1,0 +1,69 @@
+<?php
+class PagarMe_Core_Helper_BusinessCalendar
+{
+    /**
+     * @param DateTime $date
+     *
+     * @return bool
+     */
+    public function isBusinessDay($date)
+    {
+        $weekDay = $date->format('w');
+        $isWeekend = $weekDay == '0' || $weekDay == '6';
+
+        return !$isWeekend && !$this->isHoliday($date);
+    }
+
+    /**
+     * @param DateTime $date
+     * @return bool
+     */
+    public function isHoliday($date)
+    {
+        $holidayCalendar = $this->getHolidaysCalendar($date);
+
+        $isHoliday = array_filter(
+            $holidayCalendar,
+            function ($holiday) use ($date) {
+                return $holiday['date'] ==
+                    $date->format('Y-m-d');
+            }
+        );
+
+        return (bool)$isHoliday;
+    }
+
+    /**
+     * @param DateTime $date
+     *
+     * @return array
+     */
+    public function getHolidaysCalendar($date)
+    {
+        $holidaysSource = sprintf(
+            '%s%s%s',
+            'https://raw.githubusercontent.com/pagarme/',
+            'business-calendar/master/src/brazil/',
+            $this->getDateYear($date).'.json'
+        );
+
+        $holidayClient = new GuzzleHttp\Client(
+            [
+                'uri' => $holidaysSource
+            ]
+        );
+
+        $holidaysFile = $holidayClient
+            ->get($holidaysSource)
+            ->getBody()
+            ->getContents();
+
+        $holidayJson = json_decode($holidaysFile, true);
+        return $holidayJson['calendar'];
+    }
+
+    public function getDateYear($date)
+    {
+        return $date->format('Y');
+    }
+}

--- a/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
+++ b/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
@@ -131,6 +131,16 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
     }
 
     /**
+     * @return int
+     */
+    private function getDaysToBoletoExpire()
+    {
+        return (int) $this->getConfigurationWithName(
+            'pagarme_configurations/days_to_boleto_expire'
+        );
+    }
+
+    /**
      * @param string $name
      *
      * @return mixed

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.15.2</version>
+            <version>3.16.0</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -124,6 +124,7 @@
                 <creditcard_title>Pagamento com cartão de crédito</creditcard_title>
                 <modal_capture_customer_data>true</modal_capture_customer_data>
                 <boleto_discount>0</boleto_discount>
+                <days_to_boleto_expire>5</days_to_boleto_expire>
                 <boleto_discount_mode>no_discount</boleto_discount_mode>
                 <boleto_title>Pagamento com boleto</boleto_title>
                 <modal_payment_methods>credit_card,boleto</modal_payment_methods>

--- a/app/code/community/PagarMe/Core/etc/system.xml
+++ b/app/code/community/PagarMe/Core/etc/system.xml
@@ -165,6 +165,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </boleto_discount_mode>
+                        <days_to_boleto_expire translate="label">
+                            <label>Days to boleto expire</label>
+                            <frontend_type>text</frontend_type>
+                            <frontend_class>validate-number</frontend_class>
+                            <sort_order>24</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </days_to_boleto_expire>
 
                         <heading_creditcard translate="label">
                             <label>Checkout Transparente</label>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.15.2</version>
+            <version>3.16.0</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.15.2</version>
+            <version>3.16.0</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/locale/pt_BR/PagarMe_Core.csv
+++ b/app/locale/pt_BR/PagarMe_Core.csv
@@ -38,6 +38,7 @@
 "Async Transaction","Transação assíncrona"
 "Boleto discount","Desconto para boletos"
 "Boleto discount mode", "Modelo de desconto para boletos"
+"Days to boleto expire", "Dias para expiração do boleto"
 "Payment Methods","Métodos de pagamento"
 "Authorize and Capture","Autorizar e capturar"
 "Authorize Only","Somente autorizar"

--- a/tests/acceptance/features/boleto.feature
+++ b/tests/acceptance/features/boleto.feature
@@ -5,6 +5,9 @@ Feature: Boleto
 
     Scenario: Make a purchase by boleto 
         Given a registered user
+        And a admin user
+        When I access the admin
+        And I change the boleto expiration date delay to next sunday
         When I access the store page
         And add any product to basket
         And I go to checkout page
@@ -17,6 +20,7 @@ Feature: Boleto
         And a link to boleto must be provided
         And I get the created order id
         And the order status should be "pending_payment"
+        And the boleto expiration date must be a business day
 
     Scenario: Cancel order with unpaid boleto
         Given a registered user


### PR DESCRIPTION
### Descrição

Este PR corrige datas de expirações de boleto que caiam em final de semana, ou feriado, jogando a data de expiração para o próximo dia útil.

### Número da Issue
#368 

### Testes Realizados

Testes de aceitação, jogando a data de expiração do boleto para o próximo domingo, e esperando que fosse configurada para a próxima segunda-feira.