### PR TITLE
Fix/card hash invalido

### DIFF
--- a/js/pagarme/creditcard.js
+++ b/js/pagarme/creditcard.js
@@ -68,8 +68,6 @@ document.onreadystatechange = () => {
               generateHash()
                 .then(() => buttonOnClick())
             })
-            generateHash()
-              .then(() => buttonOnClick())
 
             addedEvent = true
           }
@@ -87,8 +85,6 @@ document.onreadystatechange = () => {
           generateHash()
             .then(() => buttonOnClick())
         })
-        generateHash()
-          .then(() => buttonOnClick())
 
         addedEvent = true
       }

--- a/js/pagarme/creditcard.js
+++ b/js/pagarme/creditcard.js
@@ -50,6 +50,11 @@ document.onreadystatechange = () => {
     }
 
     var addedEvent = false
+
+    get('#opc-review, #checkout-step-payment').addEventListener('click', function() {
+      addedEvent = false
+    })
+
     get('#opc-review, #checkout-review-submit').addEventListener('click', function (event) {
       if (event.path) {
         var buttons = this.getElementsByClassName('btn-checkout')


### PR DESCRIPTION
### Descrição

Corrige o problema de card_hash inválido quando o cliente digita uma informação errada, ou sai da página do checkout.

### Número da Issue

#371 

### Testes Realizados

Testes manuais garantindo o funcionamento do card_hash nessas situações.
