### PR TITLE
Implementa configuração para build/test no Circle-Ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,25 +6,10 @@ _run:
     command: |
       echo "MAGENTO_VERSION=$MAGENTO_VERSION" >> .env
       echo "IMGUR_CLIENT_ID=$IMGUR_CLIENT_ID" >> .env
-      docker-compose up -d
-      magentoIsInstalled() {
-        isInstalled=$(docker-compose exec magento php -f install.php | grep "Magento is already installed" | wc -l)
-
-        if [ $isInstalled -eq 1 ] 
-        then
-          return 0
-        else
-          return 1
-        fi
-      }
-      while ! ( magentoIsInstalled )
-      do
-        echo [$(date +"%Y-%m-%d %H:%M:%S")] - "Waiting for magento to be installed..."
-        sleep 15
-      done
-  dump-autoload: &dump-autoload
+      make up-containers
+  composer-install: &composer-install
     name: 'Dump composer autoload'
-    command: 'docker-compose run composer dump-autoload'
+    command: 'make composer-install'
 
 jobs:
   checkout-code:
@@ -45,7 +30,7 @@ jobs:
           at: ~/project
       - run:
           name: 'Avoid forgotten keys'
-          command: 'chmod +x ./forgotten_keys.sh && ./forgotten_keys.sh'
+          command: 'make check-forgotten-keys'
 
   unit:
     machine:
@@ -54,10 +39,10 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run: *up-containers
-      - run: *dump-autoload
+      - run: *composer-install
       - run:
           name: 'Running unit tests'
-          command: 'docker-compose exec magento vendor/bin/phpunit'
+          command: 'make test-unit'
 
   end-to-end:
     description: Parameterized job to run end-to-end suites
@@ -77,16 +62,21 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run: *up-containers
+<<<<<<< HEAD
       - run: *dump-autoload
+=======
+      - run: *composer-install
+      - steps: << parameters.before-deps >>
+>>>>>>> 6abd960... wip config
       - run:
           name: Running << parameters.suite_name >> end to end suite test
-          command: docker-compose exec magento vendor/bin/behat -s << parameters.suite_name >> --stop-on-failure
+          command: make test-e2e-suite suite=<< parameters.suite_name >>
       - run:
           name: Show magento's system and error logs
           when: on_fail
           command: |
-            docker-compose exec magento cat var/log/system.log
-            docker-compose exec magento cat var/log/exception.log
+            make show-system-logs
+            make show-exception-logs
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,173 @@
+version: 2.1
+
+_run:
+  up-containers: &up-containers
+    name: 'Up containers'
+    command: |
+      echo "MAGENTO_VERSION=$MAGENTO_VERSION" >> .env
+      echo "IMGUR_CLIENT_ID=$IMGUR_CLIENT_ID" >> .env
+      docker-compose up -d
+      magentoIsInstalled() {
+        isInstalled=$(docker-compose exec magento php -f install.php | grep "Magento is already installed" | wc -l)
+
+        if [ $isInstalled -eq 1 ] 
+        then
+          return 0
+        else
+          return 1
+        fi
+      }
+      while ! ( magentoIsInstalled )
+      do
+        echo [$(date +"%Y-%m-%d %H:%M:%S")] - "Waiting for magento to be installed..."
+        sleep 15
+      done
+  dump-autoload: &dump-autoload
+    name: 'Dump composer autoload'
+    command: 'docker-compose run composer dump-autoload'
+
+jobs:
+  checkout-code:
+    machine:
+      enabled: true
+    steps:
+      - checkout
+      - persist_to_workspace:
+            root: ~/project
+            paths:
+              - ./
+
+  forgotten-keys:
+    machine:
+      enabled: true
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: 'Avoid forgotten keys'
+          command: 'chmod +x ./forgotten_keys.sh && ./forgotten_keys.sh'
+
+  unit:
+    machine:
+      enabled: true
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run: *up-containers
+      - run: *dump-autoload
+      - run:
+          name: 'Running unit tests'
+          command: 'docker-compose exec magento vendor/bin/phpunit'
+
+  end-to-end:
+    description: Parameterized job to run end-to-end suites
+    parameters:
+      suite_name:
+        description: "the suite name to be ran"
+        type: string
+      magento_version:
+        description: "Magento version to be used"
+        type: string
+        default: "1.8.1.0"
+    machine:
+      enabled: true
+    environment:
+      MAGENTO_VERSION: << parameters.magento_version >>
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run: *up-containers
+      - run: *dump-autoload
+      - run:
+          name: Running << parameters.suite_name >> end to end suite test
+          command: docker-compose exec magento vendor/bin/behat -s << parameters.suite_name >> --stop-on-failure
+      - run:
+          name: Show magento's system and error logs
+          when: on_fail
+          command: |
+            docker-compose exec magento cat var/log/system.log
+            docker-compose exec magento cat var/log/exception.log
+
+workflows:
+  version: 2
+  tests:
+    jobs:
+      - checkout-code
+      - forgotten-keys:
+          requires:
+          - checkout-code
+      - unit:
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-configure-mage-1.8
+          suite_name: "configure"
+          magento_version: "1.8.1.0"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-credit_card-mage-1.8
+          suite_name: "credit_card"
+          magento_version: "1.8.1.0"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-boleto-mage-1.8
+          suite_name: "boleto"
+          magento_version: "1.8.1.0"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-postback-mage-1.8
+          suite_name: "postback"
+          magento_version: "1.8.1.0"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-configure-mage-1.7
+          suite_name: "configure"
+          magento_version: "1.7.0.2"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-credit_card-mage-1.7
+          suite_name: "credit_card"
+          magento_version: "1.7.0.2"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-boleto-mage-1.7
+          suite_name: "boleto"
+          magento_version: "1.7.0.2"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-postback-mage-1.7
+          suite_name: "postback"
+          magento_version: "1.7.0.2"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-configure-mage-1.9
+          suite_name: "configure"
+          magento_version: "1.9.1.0"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-credit_card-mage-1.9
+          suite_name: "credit_card"
+          magento_version: "1.9.1.0"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-boleto-mage-1.9
+          suite_name: "boleto"
+          magento_version: "1.9.1.0"
+          requires:
+            - forgotten-keys
+      - end-to-end:
+          name: e2e-postback-mage-1.9
+          suite_name: "postback"
+          magento_version: "1.9.1.0"
+          requires:
+            - forgotten-keys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,10 @@ jobs:
         description: "Magento version to be used"
         type: string
         default: "1.8.1.0"
+      before-deps:
+        description: "Steps that should be run before the test suite"
+        type: steps
+        default: []
     machine:
       enabled: true
     environment:
@@ -62,12 +66,8 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run: *up-containers
-<<<<<<< HEAD
-      - run: *dump-autoload
-=======
       - run: *composer-install
       - steps: << parameters.before-deps >>
->>>>>>> 6abd960... wip config
       - run:
           name: Running << parameters.suite_name >> end to end suite test
           command: make test-e2e-suite suite=<< parameters.suite_name >>
@@ -111,6 +111,8 @@ workflows:
           name: e2e-postback-mage-1.8
           suite_name: "postback"
           magento_version: "1.8.1.0"
+          before-deps:
+            - run: make test-e2e-suite suite=configure
           requires:
             - forgotten-keys
       - end-to-end:
@@ -135,6 +137,8 @@ workflows:
           name: e2e-postback-mage-1.7
           suite_name: "postback"
           magento_version: "1.7.0.2"
+          before-deps:
+            - run: make test-e2e-suite suite=configure
           requires:
             - forgotten-keys
       - end-to-end:
@@ -159,5 +163,7 @@ workflows:
           name: e2e-postback-mage-1.9
           suite_name: "postback"
           magento_version: "1.9.1.0"
+          before-deps:
+            - run: make test-e2e-suite suite=configure
           requires:
             - forgotten-keys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,22 @@ jobs:
           command: 'make check-forgotten-keys'
 
   unit:
+    description: Parameterized job to run unit tests
+    parameters:
+      magento_version:
+        description: "Magento version to be used"
+        type: string
+        default: "1.8.1.0"
     machine:
       enabled: true
+    environment:
+      MAGENTO_VERSION: << parameters.magento_version >>
     steps:
       - attach_workspace:
           at: ~/project
       - run: *up-containers
       - run:
-          name: 'Running unit tests'
+          name: 'Running unit tests against magento << parameters.magento_version >>'
           command: 'make test-unit'
 
   end-to-end:
@@ -102,6 +110,20 @@ workflows:
           requires:
           - checkout-code
       - unit:
+          name: unit-mage-1.7
+          magento_version: "1.7.0.2"
+          requires:
+            - forgotten-keys
+            - install-dependencies
+      - unit:
+          name: unit-mage-1.8
+          magento_version: "1.8.1.0"
+          requires:
+            - forgotten-keys
+            - install-dependencies
+      - unit:
+          name: unit-mage-1.9
+          magento_version: "1.9.1.0"
           requires:
             - forgotten-keys
             - install-dependencies
@@ -110,22 +132,19 @@ workflows:
           suite_name: "configure"
           magento_version: "1.8.1.0"
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.8
       - end-to-end:
           name: e2e-credit_card-mage-1.8
           suite_name: "credit_card"
           magento_version: "1.8.1.0"
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.8
       - end-to-end:
           name: e2e-boleto-mage-1.8
           suite_name: "boleto"
           magento_version: "1.8.1.0"
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.8
       - end-to-end:
           name: e2e-postback-mage-1.8
           suite_name: "postback"
@@ -133,29 +152,25 @@ workflows:
           before-deps:
             - run: make test-e2e-suite suite=configure
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.8
       - end-to-end:
           name: e2e-configure-mage-1.7
           suite_name: "configure"
           magento_version: "1.7.0.2"
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.7
       - end-to-end:
           name: e2e-credit_card-mage-1.7
           suite_name: "credit_card"
           magento_version: "1.7.0.2"
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.7
       - end-to-end:
           name: e2e-boleto-mage-1.7
           suite_name: "boleto"
           magento_version: "1.7.0.2"
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.7
       - end-to-end:
           name: e2e-postback-mage-1.7
           suite_name: "postback"
@@ -163,29 +178,25 @@ workflows:
           before-deps:
             - run: make test-e2e-suite suite=configure
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.7
       - end-to-end:
           name: e2e-configure-mage-1.9
           suite_name: "configure"
           magento_version: "1.9.1.0"
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.9
       - end-to-end:
           name: e2e-credit_card-mage-1.9
           suite_name: "credit_card"
           magento_version: "1.9.1.0"
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.9
       - end-to-end:
           name: e2e-boleto-mage-1.9
           suite_name: "boleto"
           magento_version: "1.9.1.0"
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.9
       - end-to-end:
           name: e2e-postback-mage-1.9
           suite_name: "postback"
@@ -193,5 +204,4 @@ workflows:
           before-deps:
             - run: make test-e2e-suite suite=configure
           requires:
-            - forgotten-keys
-            - install-dependencies
+            - unit-mage-1.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ _run:
       echo "IMGUR_CLIENT_ID=$IMGUR_CLIENT_ID" >> .env
       make up-containers
   composer-install: &composer-install
-    name: 'Dump composer autoload'
+    name: 'Install dependencies'
     command: 'make composer-install'
 
 jobs:
@@ -17,6 +17,20 @@ jobs:
       enabled: true
     steps:
       - checkout
+      - persist_to_workspace:
+            root: ~/project
+            paths:
+              - ./
+
+  install-dependencies:
+    machine:
+      enabled: true
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Install composer dependencies
+          command: make composer-install
       - persist_to_workspace:
             root: ~/project
             paths:
@@ -39,7 +53,6 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run: *up-containers
-      - run: *composer-install
       - run:
           name: 'Running unit tests'
           command: 'make test-unit'
@@ -66,7 +79,6 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run: *up-containers
-      - run: *composer-install
       - steps: << parameters.before-deps >>
       - run:
           name: Running << parameters.suite_name >> end to end suite test
@@ -86,27 +98,34 @@ workflows:
       - forgotten-keys:
           requires:
           - checkout-code
+      - install-dependencies:
+          requires:
+          - checkout-code
       - unit:
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-configure-mage-1.8
           suite_name: "configure"
           magento_version: "1.8.1.0"
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-credit_card-mage-1.8
           suite_name: "credit_card"
           magento_version: "1.8.1.0"
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-boleto-mage-1.8
           suite_name: "boleto"
           magento_version: "1.8.1.0"
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-postback-mage-1.8
           suite_name: "postback"
@@ -115,24 +134,28 @@ workflows:
             - run: make test-e2e-suite suite=configure
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-configure-mage-1.7
           suite_name: "configure"
           magento_version: "1.7.0.2"
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-credit_card-mage-1.7
           suite_name: "credit_card"
           magento_version: "1.7.0.2"
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-boleto-mage-1.7
           suite_name: "boleto"
           magento_version: "1.7.0.2"
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-postback-mage-1.7
           suite_name: "postback"
@@ -141,24 +164,28 @@ workflows:
             - run: make test-e2e-suite suite=configure
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-configure-mage-1.9
           suite_name: "configure"
           magento_version: "1.9.1.0"
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-credit_card-mage-1.9
           suite_name: "credit_card"
           magento_version: "1.9.1.0"
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-boleto-mage-1.9
           suite_name: "boleto"
           magento_version: "1.9.1.0"
           requires:
             - forgotten-keys
+            - install-dependencies
       - end-to-end:
           name: e2e-postback-mage-1.9
           suite_name: "postback"
@@ -167,3 +194,4 @@ workflows:
             - run: make test-e2e-suite suite=configure
           requires:
             - forgotten-keys
+            - install-dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+default: up-containers composer-install tailf-magento-logs toggle-mage-logs enable-mage-errors
+
+wait-for-magento:
+	@./script/wait-for-magento.sh
+
+up-containers:
+	@docker-compose up -d
+
+tailf-magento-logs:
+	docker-compose logs -f magento
+
+down:
+	@docker-compose down
+
+check-forgotten-keys:
+	@./forgotten_keys.sh
+
+test-unit: wait-for-magento
+	@docker-compose exec magento vendor/bin/phpunit
+
+test-e2e: wait-for-magento
+	@docker-compose exec magento vendor/bin/behat --stop-on-failure
+
+test-e2e-suite: wait-for-magento
+	@docker-compose exec magento vendor/bin/behat -s $(suite) --stop-on-failure
+
+composer-install:
+	@docker-compose run composer install
+
+toggle-mage-logs:
+	@docker-compose exec magento vendor/bin/n98-magerun dev:log
+
+enable-mage-errors:
+	@docker-compose exec magento mv errors/local.xml.sample errors/local.xml
+
+get-api-key:
+	@docker-compose exec magento vendor/bin/n98-magerun config:get payment/pagarme_configurations/general_api_key
+
+set-api-key:
+	@docker-compose exec magento vendor/bin/n98-magerun config:set $(api_key)
+
+show-system-logs:
+	docker-compose exec magento cat var/log/system.log
+
+show-exception-logs:
+	docker-compose exec magento cat var/log/exception.log
+
+tailf-system-logs:
+	docker-compose exec magento tail -f var/log/system.log
+
+tailf-exception-logs:
+	docker-compose exec magento tail -f var/log/exception.log

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,6 @@ tailf-system-logs:
 
 tailf-exception-logs:
 	docker-compose exec magento tail -f var/log/exception.log
+
+phpcs:
+	@docker-compose exec magento vendor/bin/phpcs --standard=phpcsruleset.xml $(target)

--- a/README.md
+++ b/README.md
@@ -57,30 +57,78 @@ Mais detalhes sobre esta configuração no [link](https://amasty.com/blog/config
 
 - [Docker](https://docs.docker.com)
 - [Docker Compose](https://docs.docker.com/compose/)
+- [GNU Make (Opcional)](https://www.gnu.org/software/make/)
 
 ### Instalando o Magento Community 1.x
 
-1. Execute o comando `docker-compose up -d` para iniciar os containers e a instalação do Magento
-2. Execute o comando `docker-compose logs -f magento` para acompanhar o processo de instalação.
-3. Execute o comando `docker run -it --rm -v $(pwd):/code -w /code pagarme/composer install` para a instalação das dependências do projeto através do [Composer](https://getcomposer.org/).
+1. Clonando o projeto
+```
+git clone git@github.com:pagarme/pagarme-magento.git
+```
+
+2. Preparando o ambiente (containers)
+
+**Obs:** Utilizamos o `make` para tornar a utilização mais amigável mas é possível obter os mesmos resultados executando comandos através dos containers utilizando o `docker-compose`. Para isso basta consultar o `Makefile` do projeto.
+
+```
+make
+```
+
+O comando acima irá:
+- Subir os containers docker
+- Instalar as dependências do projeto através do [Composer](https://getcomposer.org)
+- Habilitar os logs da plataforma (system e exception)
+- Habilitar a exibição de erros da plataforma
 
 ### Executando o PHPCS (Code sniffer)
 
-Execute o comando: `docker-compose exec magento vendor/bin/phpcs --standard=phpcsruleset.xml <dir|file>`
+```
+make phpcs target=NOME DO ARQUIVO OU DIRETORIO
+```
 
 ### Executando os testes unitários
 
-Execute o comando `docker-compose exec magento vendor/bin/phpunit` para iniciar os testes
+```make test-unit```
 
 ### Executando os testes de comportamento
 
-Execute o comando `docker-compose exec magento vendor/bin/behat` para iniciar os testes
+a) Todas as suites de teste
+```make test-e2e```
+
+b) Uma suite específica. Veja todas as disponíveis no [behat.yml](https://github.com/pagarme/pagarme-magento/blob/v2/behat.yml#L12) do projeto
+```make test-e2e-suite suite=NOME_DA_SUITE```
 
 ### Acompanhando a execução dos testes de comportamento
 
 1. Instale um cliente VNC. Sugerimos o [Vinagre](https://wiki.gnome.org/Apps/Vinagre)
 2. Conecte-se no servidor.
 *  Utilize `localhost` para o host e `secret` para senha
+
+### Comandos úteis para desenvolvimento
+
+Todos os comandos podem ser conferidos no arquivo [Makefile](https://github.com/pagarme/pagarme-magento/blob/v2/Makefile) do projeto
+
+1. "Matando" os containers
+```
+make down
+```
+
+2. Acompanhando (tail -f) os logs do magento
+```
+make tailf-system-logs
+ou
+make tailf-exception-logs
+```
+
+3. Recuperando api key (Pagar.me) configurada no módulo
+```
+make get-api-key
+```
+
+4. Alterando api key (Pagar.me)
+```
+make set-api-key api_key=SUA_API_KEY
+```
 
 ### Testando postbacks em ambiente de desenvolvimento
 

--- a/forgotten_keys.sh
+++ b/forgotten_keys.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-grep -REl "(ak_test|ak_live|ek_test|ek_live)_([a-zA-Z0-9]*)" .
+grep -REl "(ak_test|ak_live|ek_test|ek_live)_([a-zA-Z0-9]*)" ./app ./tests ./skin ./js
 LINES_FOUNDED=$?
 if [ ! $LINES_FOUNDED -eq 1 ]; then
     # key was founded so exit 1

--- a/script/wait-for-magento.sh
+++ b/script/wait-for-magento.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 magentoIsInstalled() {
   isInstalled=$(docker-compose exec magento php -f install.php | grep "Magento is already installed" | wc -l)
 

--- a/script/wait-for-magento.sh
+++ b/script/wait-for-magento.sh
@@ -1,0 +1,28 @@
+magentoIsInstalled() {
+  isInstalled=$(docker-compose exec magento php -f install.php | grep "Magento is already installed" | wc -l)
+
+  if [ $isInstalled -eq 1 ] 
+  then
+    return 0
+  else
+    return 1
+  fi
+}
+
+magentoHasBeenDownloaded() {
+  docker-compose exec magento test -e install.php
+
+  if [ $? -eq 0 ]
+  then
+    return 0
+  else
+    return 1
+  fi
+}
+
+
+while ! ( magentoHasBeenDownloaded && magentoIsInstalled )
+do
+  echo [$(date +"%Y-%m-%d %H:%M:%S")] - "Waiting for magento to be installed..."
+  sleep 5
+done

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -950,7 +950,7 @@ class CreditCardContext extends RawMinkContext
      */
     public function IMustStayInTheCheckoutPage() {
         try {
-            $this->session->wait(5000);
+            $this->session->wait(5500);
             \PHPUnit_Framework_TestCase::assertEquals(
                 getenv('MAGENTO_URL') . 'index.php/checkout/onepage/index/',
                 $this->session->getCurrentUrl()


### PR DESCRIPTION
### Descrição

Dado que o processo de build no Travis-ci é bem demorado e pouco performático. Esse PR inclui um arquivo de configuração que vai permitir executar o mesmo processo no circle ci. O arquivo do travis ainda não foi removido dado que é uma mudança um tanto drástica portanto acredito que seja prudente  manter os dois em funcionamento até conseguirmos validar que a mudança de fato atendo as nossas expectativas.

### Testes Realizados

Testes manuais através da dashboard do circle-ci.