### PR TITLE
One step checkout: corrige problema ao finalizar compra com boleto

### DIFF
--- a/js/pagarme/creditcard-osc.js
+++ b/js/pagarme/creditcard-osc.js
@@ -37,6 +37,6 @@ document.onreadystatechange = () => {
       clearHash()
       return generateHash()
     }
-    return Promise.reject(new Error('Can\'t generate the cardHash'))
+    return Promise.resolve()
   }, 'click', placeOrderButton)
 }


### PR DESCRIPTION
### Descrição

Ao tentar finalizar compra com boleto no one step checkout, o módulo está caindo em um `Promise.reject` que interrompe o fluxo do magento, fazendo com que a compra não seja finalizada.

Abaixo segue a diferença de utilizar `Promise.reject` e `Promise.resolve`:

**Promise.reject**
![magento - com promise reject](https://user-images.githubusercontent.com/18074134/52432435-84805a80-2af1-11e9-99ad-17c37345ff0e.gif)

---

**Promise resolve**
![magento - com promise resolve](https://user-images.githubusercontent.com/18074134/52432447-8ba76880-2af1-11e9-8227-586a995d64d0.gif)

Como pode notar nos gifs acima, a compra não é finalizada quando o `Promise.reject` é chamado.

### Número da Issue

Sem Issue.

### Testes Realizados

Testes manuais com One Step Checkout