### PR TITLE
captura do pedido: considera juros no ato da captura

### DIFF
--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.17.1</version>
+            <version>3.17.2</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.17.1</version>
+            <version>3.17.2</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/Model/Installments.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Installments.php
@@ -85,4 +85,12 @@ class PagarMe_CreditCard_Model_Installments
 
         return $installments[$installment]['total_amount'];
     }
+
+    /**
+     * @return int
+     */
+    public function getRateAmount()
+    {
+        return intval($this->getTotal() - $this->amount);
+    }
 }

--- a/app/code/community/PagarMe/CreditCard/Model/InvoiceTotals.php
+++ b/app/code/community/PagarMe/CreditCard/Model/InvoiceTotals.php
@@ -1,7 +1,15 @@
 <?php
 
-class PagarMe_CreditCard_Model_InvoiceTotals extends  Mage_Sales_Model_Order_Invoice_Total_Abstract
+use PagarMe_CreditCard_Model_Installments as Installments;
+
+class PagarMe_CreditCard_Model_InvoiceTotals extends Mage_Sales_Model_Order_Invoice_Total_Abstract
 {
+    use PagarMe_Core_Trait_ConfigurationsAccessor;
+
+    /**
+     * @var Mage_Sales_Model_Order
+     */
+    protected $order;
 
     /**
      * @param Mage_Sales_Model_Order_Invoice $invoice
@@ -10,11 +18,19 @@ class PagarMe_CreditCard_Model_InvoiceTotals extends  Mage_Sales_Model_Order_Inv
      */
     public function collect(Mage_Sales_Model_Order_Invoice $invoice)
     {
-        $order = $invoice->getOrder();
+        $this->order = $invoice->getOrder();
+
         $transaction = \Mage::getModel('pagarme_core/service_order')
             ->getTransactionByOrderId(
-                $order->getId()
+                $this->order->getId()
             );
+
+        if ($this->shouldUpdateRateAmount($transaction)) {
+            $transaction->setRateAmount(
+                $this->updateRateAmount($transaction, $invoice)
+            );
+        }
+
         $invoice->setGrandTotal(
             $invoice->getGrandTotal() + $transaction->getRateAmount()
         );
@@ -23,5 +39,63 @@ class PagarMe_CreditCard_Model_InvoiceTotals extends  Mage_Sales_Model_Order_Inv
         );
 
         return $this;
+    }
+
+    /**
+     * @param PagarMe_Core_Model_Transaction $transaction
+     * @param Mage_Sales_Model_Order_Invoice $invoice
+     *
+     * @return float
+     */
+    private function updateRateAmount(
+        PagarMe_Core_Model_Transaction $transaction,
+        Mage_Sales_Model_Order_Invoice $invoice
+    ) {
+        $sdk = Mage::getModel('pagarme_core/sdk_adapter')
+            ->getPagarMeSdk();
+
+        $orderTotal =
+            $invoice->getGrandTotal() + $this->order->getShippingAmount();
+
+        $installments = new Installments(
+            Mage::helper('pagarme_core')
+                ->parseAmountToCents($orderTotal),
+            $transaction->getInstallments(),
+            $this->getFreeInstallmentStoreConfig(),
+            $transaction->getInterestRate(),
+            $this->getMaxInstallmentStoreConfig(),
+            $sdk
+        );
+
+        $updatedRateAmount = Mage::helper('pagarme_core')
+            ->parseAmountToCurrency($installments->getRateAmount());
+
+        $writeConnection = Mage::getSingleton('core/resource')
+            ->getConnection('core_write');
+
+        $updateRateAmountQuery = sprintf(
+            'UPDATE pagarme_transaction SET %s',
+            'rate_amount = :rateAmount WHERE order_id = :orderId;'
+        );
+
+        $queryValues = [
+            'rateAmount' => $updatedRateAmount,
+            'orderId' => $this->order->getId()
+        ];
+
+        $writeConnection->query($updateRateAmountQuery, $queryValues);
+
+        return $updatedRateAmount;
+    }
+
+    /**
+     * @param PagarMe_Core_Model_Transaction $transaction
+     *
+     * @return bool
+     */
+    private function shouldUpdateRateAmount(
+        PagarMe_Core_Model_Transaction $transaction
+    ) {
+        return (bool)$transaction->getInterestRate();
     }
 }

--- a/app/code/community/PagarMe/CreditCard/Model/InvoiceTotals.php
+++ b/app/code/community/PagarMe/CreditCard/Model/InvoiceTotals.php
@@ -1,0 +1,27 @@
+<?php
+
+class PagarMe_CreditCard_Model_InvoiceTotals extends  Mage_Sales_Model_Order_Invoice_Total_Abstract
+{
+
+    /**
+     * @param Mage_Sales_Model_Order_Invoice $invoice
+     *
+     * @return PagarMe_CreditCard_Model_InvoiceTotals
+     */
+    public function collect(Mage_Sales_Model_Order_Invoice $invoice)
+    {
+        $order = $invoice->getOrder();
+        $transaction = \Mage::getModel('pagarme_core/service_order')
+            ->getTransactionByOrderId(
+                $order->getId()
+            );
+        $invoice->setGrandTotal(
+            $invoice->getGrandTotal() + $transaction->getRateAmount()
+        );
+        $invoice->setBaseGrandTotal(
+            $invoice->getBaseGrandTotal() + $transaction->getRateAmount()
+        );
+
+        return $this;
+    }
+}

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.17.1</version>
+            <version>3.17.2</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -14,6 +14,13 @@
                     </pagarme_creditcard_totals>
                 </totals>
             </order_creditmemo>
+            <order_invoice>
+                <totals>
+                    <pagarme_creditcard_totals>
+                        <class>pagarme_creditcard/invoiceTotals</class>
+                    </pagarme_creditcard_totals>
+                </totals>
+            </order_invoice>
             <quote>
                 <totals>
                     <pagarme_creditcard_interest>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.17.1</version>
+            <version>3.17.2</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/design/adminhtml/default/default/layout/pagarme/pagarme_creditcard.xml
+++ b/app/design/adminhtml/default/default/layout/pagarme/pagarme_creditcard.xml
@@ -5,12 +5,22 @@
             <block type="pagarme_creditcard/sales_RateAmount" name="pagarme_creditcard.rateamount"/>
         </reference>
     </adminhtml_sales_order_view>
+    <adminhtml_sales_order_invoice_new>
+        <reference name="invoice_totals">
+            <block type="pagarme_creditcard/sales_InvoiceRateAmount" name="pagarme_creditcard.invoicerateamount"/>
+        </reference>
+    </adminhtml_sales_order_invoice_new>
+    <adminhtml_sales_order_invoice_updateqty>
+        <reference name="invoice_totals">
+            <block type="pagarme_creditcard/sales_InvoiceRateAmount" name="pagarme_creditcard.invoicerateamount"/>
+        </reference>
+    </adminhtml_sales_order_invoice_updateqty>
     <adminhtml_sales_order_invoice_view>
         <reference name="invoice_totals">
             <block type="pagarme_creditcard/sales_InvoiceRateAmount" name="pagarme_creditcard.invoicerateamount"/>
         </reference>
     </adminhtml_sales_order_invoice_view>
-    
+
     <adminhtml_sales_order_creditmemo_new>
         <reference name="creditmemo_totals">
             <block type="pagarme_creditcard/sales_RefundTransaction" name="pagarme_creditcard.refundtransaction"/>

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -186,7 +186,7 @@ Feature: Credit Card
         Then the order should be "refunded" on Magento
         And the order must be "refunded" "partially" on Pagar.me
 
-    Scenario: Capture a order with interest rate through the platform
+    Scenario: Capture fully a order with interest rate through the platform
         Given a registered user
         And set a max installment as "10" and interest rate as "10"
         And the administrator set payment action to "authorize_only"

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -165,17 +165,17 @@ Feature: Credit Card
         And click on the invoice button
         And select to capture amount "online"
         And click on the submit invoice button
-        Then the order should be captured on Pagar.me
+        Then the order should be "captured" on Magento
 
     Scenario: Capture partially a purchase by credit card through the platform
         Given an "pending_payment" order with more than one product
         When I login to the admin
-        And I go to the new invoice page
+        And I go to the create new invoice page
         And I set the product quantity to "3"
         And select to capture amount "online"
         And click on the submit invoice button
-        Then the order should be "captured" on Pagar.me
-        And the order must be "captured" partially on Pagar.me
+        Then the order should be "captured" on Magento
+        And the order must be "captured" "partially" on Pagar.me
 
     Scenario: Refund partially a purchase by credit card through the platform
         Given an "processing" order with more than one product
@@ -183,5 +183,29 @@ Feature: Credit Card
         And I go to the invoice credit memo page
         And I set the product quantity to "1"
         And click on the refund button
-        Then the order should be "refunded" on Pagar.me
-        And the order must be "refunded" partially on Pagar.me
+        Then the order should be "refunded" on Magento
+        And the order must be "refunded" "partially" on Pagar.me
+
+    Scenario: Capture a order with interest rate through the platform
+        Given a registered user
+        And set a max installment as "10" and interest rate as "10"
+        And the administrator set payment action to "authorize_only"
+        And the administrator set the async configuration to "no"
+        When I access the store page
+        And add any product to basket
+        And update the product quantity to "3"
+        And I go to checkout page
+        And login with registered user
+        And confirm billing and shipping address information
+        And choose pay with transparent checkout using credit card
+        And I choose 5
+        And I confirm my payment information
+        And place order
+        Then the purchase must be paid with success
+        And I get the created order id from success page
+        When I login to the admin
+        And I go to the create new invoice page
+        And select to capture amount "online"
+        And click on the submit invoice button
+        Then the order should be "captured" on Magento
+        And the order must be "captured" "fully" on Pagar.me


### PR DESCRIPTION
### Descrição

Passa a considerar os juros do pedido no ato de captura.

Antes disso, a transação era capturada sem considerar os juros do pedido.

Sobre a raw query no código:
O Magento possui uma interface para fazer essas queries pelo próprio código, porém nossa tabela possui duas chaves primárias, e aparentemente essa interface não consegue lidar com isso.

Novo comportamento:
![interest rate](https://user-images.githubusercontent.com/18074134/52974466-760f2a00-33a0-11e9-8cbf-8765c6899183.gif)


### Número da Issue
#387 

### Testes Realizados
Testes manuais e de integração