### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/tests/acceptance/CheckoutContext.php
+++ b/tests/acceptance/CheckoutContext.php
@@ -515,7 +515,7 @@ class CheckoutContext extends RawMinkContext
         );
         \PHPUnit_Framework_TestCase::assertEquals(
             $checkoutButton,
-            NULL
+            null
         );
     }
 

--- a/tests/acceptance/OneStepCheckoutContext.php
+++ b/tests/acceptance/OneStepCheckoutContext.php
@@ -640,7 +640,7 @@ class OneStepCheckoutContext extends RawMinkContext
         );
         \PHPUnit_Framework_TestCase::assertEquals(
             $checkoutButton,
-            NULL
+            null
         );
     }
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!