### PR TITLE
credit_card: set default selected installment

### DIFF
--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.18.1</version>
+            <version>3.18.2</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.18.1</version>
+            <version>3.18.2</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/Block/Form/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Block/Form/Creditcard.php
@@ -63,4 +63,18 @@ class PagarMe_Creditcard_Block_Form_CreditCard extends Mage_Payment_Block_Form_C
 
         return $maxInstallments;
     }
+
+    /**
+     * @return int
+     */
+    public function getFreeInstallmentsConfig() {
+        return $this->getFreeInstallmentStoreConfig();
+    }
+
+    /**
+     * @return float
+     */
+    public function getInterestRateStoreConfig() {
+      return $this->getFreeInstallmentStoreConfig();
+  }
 }

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -278,7 +278,7 @@ class PagarMe_CreditCard_Model_Creditcard extends PagarMe_Core_Model_AbstractPay
     {
         if ($installments <= 0) {
             $message = $this->pagarmeCoreHelper->__(
-                'Installments number should be greater than zero. Was: '
+                'Please, select the number of installments'
             );
             throw new InvalidInstallmentsException($message . $installments);
         }
@@ -660,7 +660,7 @@ class PagarMe_CreditCard_Model_Creditcard extends PagarMe_Core_Model_AbstractPay
         } catch (InvalidInstallmentsException $exception) {
             Mage::log($exception->getMessage());
             Mage::logException($exception);
-            Mage::throwException($exception);
+            Mage::throwException($exception->getMessage());
         } catch (TransactionsInstallmentsDivergent $exception) {
             Mage::log($exception->getMessage());
             Mage::logException($exception);

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.18.1</version>
+            <version>3.18.2</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.18.1</version>
+            <version>3.18.2</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
@@ -81,20 +81,35 @@
                         title="<?= $helper->__('Installments') ?>"
                         class="input-text required-entry"
                     >
+                    <option value="0">
+                      <?= Mage::helper('pagarme_core')->__('Please, select the number of installments'); ?>
+                    </option>
                     <?php foreach ($this->getInstallments() as $installmentNumber => $installmentInfo) : ?>
                         <option value="<?= $installmentNumber ?>">
                             <?php
                                 $moduleHelper = Mage::helper('pagarme_core');
-                                $floatPrice = $moduleHelper
+                                $floatInstallmentAmount = $moduleHelper
                                     ->parseAmountToCurrency(
                                         $installmentInfo['installment_amount']
                                     );
-                                echo sprintf(
-                                    '%sx - (%s x R$%s)',
-                                    $installmentNumber,
-                                    $installmentNumber,
-                                    $moduleHelper->formatFloatToCurrentLocale($floatPrice)
+                                $floatInstallmentTotalAmount = $moduleHelper
+                                    ->parseAmountToCurrency(
+                                        $installmentInfo['total_amount']
                                 );
+                                if ((int)$installmentNumber <= $this->getFreeInstallmentsConfig()) {
+                                  echo sprintf(
+                                    '%sx R$ %s (sem juros)',
+                                    $installmentNumber,
+                                    number_format($floatInstallmentAmount, 2, ",", ".")
+                                  );
+                                } else {
+                                  echo sprintf(
+                                    '%sx R$ %s (total R$ %s)',
+                                    $installmentNumber,
+                                    number_format($floatInstallmentAmount, 2, ",", "."),
+                                    number_format($floatInstallmentTotalAmount, 2, ",", ".")
+                                  );
+                                }
                             ?>
                         </option>
                     <?php endforeach; ?>

--- a/app/locale/pt_BR/PagarMe_Core.csv
+++ b/app/locale/pt_BR/PagarMe_Core.csv
@@ -58,3 +58,4 @@
 "Paid","Pago"
 "Minimum Installment Value","Valor mínimo por parcela"
 "Example 5.99","Exemplo 5.00"
+"Please, select the number of installments","Por favor, selecione o número de parcelas"

--- a/tests/acceptance/CreditCardContext.php
+++ b/tests/acceptance/CreditCardContext.php
@@ -543,11 +543,17 @@ class CreditCardContext extends RawMinkContext
      */
     public function iShouldSeeOnlyInstallmentOptionsUpTo($maxInstallments)
     {
-        $this->assertSession()->elementsCount(
-            'css',
-            '#pagarme_creditcard_creditcard_installments > option',
-            intval($maxInstallments)
+        $page = $this->session->getPage();
+
+        $lastInstallment = $page
+            ->find('css', '#pagarme_creditcard_creditcard_installments :last-child')
+            ->getAttribute('value');
+
+        \PHPUnit_Framework_TestCase::assertEquals(
+            $lastInstallment,
+            $maxInstallments
         );
+
         $this->assertThereIsEveryOptionValueUntil(
             $maxInstallments,
             '#pagarme_creditcard_creditcard_installments'
@@ -558,7 +564,7 @@ class CreditCardContext extends RawMinkContext
         $maxValue,
         $selectCssSelector
     ) {
-        for ($value = 1; $value <= $maxValue; $value++) {
+        for ($value = 0; $value <= $maxValue; $value++) {
             $this->assertSession()->elementExists(
                 'css',
                 $selectCssSelector . " > option[value={$value}]"

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -14,6 +14,7 @@ Feature: Credit Card
         And login with registered user
         And confirm billing and shipping address information
         And choose pay with transparent checkout using credit card
+        And I choose 1
         And I confirm my payment information
         And place order
         Then the purchase must be paid with success
@@ -35,6 +36,7 @@ Feature: Credit Card
         And login with registered user
         And confirm billing and shipping address information
         And choose pay with transparent checkout using credit card
+        And I choose 1
         And I give a invalid payment information
         And place order
         Then I must stay in the checkout page
@@ -49,6 +51,7 @@ Feature: Credit Card
         And confirm billing and shipping address information
         And choose pay with transparent checkout using credit card
         And I give a invalid payment information
+        And I choose 1
         And place order
         Then the purchase must be paid with success
         And I get the created order id from success page
@@ -64,6 +67,7 @@ Feature: Credit Card
         And login with registered user
         And confirm billing and shipping address information
         And choose pay with transparent checkout using credit card
+        And I choose 1
         And I confirm my payment information
         And I should see only installment options up to "<desired_max_installment>"
         And place order


### PR DESCRIPTION
### Descrição
Ao recarregar o formulário de dados de cartão, o campo de parcelas é resetado. Então se o cliente selecionar 10, e recarregar o formulário, as parcelas irão voltar para 1, induzindo o cliente ao erro. Com essa alteração, o valor default das parcelas é inválido e um erro é exibido caso o cliente tente finalizar a compra sem selecionar o número de parcelas desejada.

Além disso, esse PR também altera a exibição do texto de seleção de parcelas de:
2x - (2 x R$5.50)
para
2x R$ 5.50 (total R$11.00)

### Número da Issue

Closes #396 

### Testes Realizados

Testes manuais e e2e