### PR TITLE
payment_capture: enable/disable boleto and/or creditcard accordingly admin config

### DIFF
--- a/app/code/community/PagarMe/Bowleto/Model/Boleto.php
+++ b/app/code/community/PagarMe/Bowleto/Model/Boleto.php
@@ -88,22 +88,6 @@ class PagarMe_Bowleto_Model_Boleto extends PagarMe_Core_Model_AbstractPaymentMet
         return $this;
     }
 
-    /**
-     * @param type $quote
-     *
-     * @return bool
-     */
-    public function isAvailable($quote = null)
-    {
-        if (!parent::isAvailable($quote)) {
-            return false;
-        }
-
-        return (bool) Mage::getStoreConfig(
-            'payment/pagarme_configurations/transparent_active'
-        );
-    }
-
    /**
     * Retrieve payment method title
     *

--- a/app/code/community/PagarMe/Core/Model/AbstractPaymentMethod.php
+++ b/app/code/community/PagarMe/Core/Model/AbstractPaymentMethod.php
@@ -33,4 +33,41 @@ abstract class PagarMe_Core_Model_AbstractPaymentMethod extends Mage_Payment_Mod
 
         return $postbackUrl;
     }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->_code;
+    }
+
+    /**
+     * Return boolean depending on a module system configuration
+     *
+     * @see    app/code/community/PagarMe/Core/etc/system.xml
+     * @return boolean
+     */
+    public function isTransparentCheckoutActive()
+    {
+        return $this->isTransparentCheckoutActiveStoreConfig();
+    }
+
+    /**
+     * Check whether payment method can be used
+     *
+     * @param Mage_Sales_Model_Quote|null $quote
+     *
+     * @return boolean
+     */
+    public function isAvailable($quote = null)
+    {
+        $isInAvailableCaptureMethods = strpos(
+            $this->getActiveTransparentPaymentMethod(),
+            $this->getCode()
+        );
+
+        return $this->isTransparentCheckoutActive()
+            && $isInAvailableCaptureMethods !== false;
+    }
 }

--- a/app/code/community/PagarMe/Core/Model/System/Config/Source/PaymentMethods.php
+++ b/app/code/community/PagarMe/Core/Model/System/Config/Source/PaymentMethods.php
@@ -11,16 +11,18 @@ class PagarMe_Core_Model_System_Config_Source_PaymentMethods
     {
         return [
             [
-                'value' => 'boleto',
+                'value' => 'pagarme_bowleto',
                 'label' => Mage::helper('pagarme_core')->__('Boleto Only')
             ],
             [
-                'value' => 'credit_card',
+                'value' => 'pagarme_creditcard',
                 'label' => Mage::helper('pagarme_core')->__('Credit Card Only')
             ],
             [
-                'value' => 'credit_card,boleto',
-                'label' => Mage::helper('pagarme_core')->__('Boleto and Credit Card')
+                'value' => 'pagarme_creditcard,pagarme_bowleto',
+                'label' => Mage::helper('pagarme_core')->__(
+                    'Boleto and Credit Card'
+                )
             ]
         ];
     }

--- a/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
+++ b/app/code/community/PagarMe/Core/Trait/ConfigurationsAccessor.php
@@ -51,6 +51,21 @@ trait PagarMe_Core_Trait_ConfigurationsAccessor
     }
 
     /**
+     * Returns wich payment method is available on checkou transparent:
+     * credit card, boleto and/or credit card and boleto
+     *
+     * @see app/code/community/PagarMe/Core/etc/system.xml
+     *
+     * @return string
+     */
+    public function getActiveTransparentPaymentMethod()
+    {
+        return $this->getConfigurationWithName(
+            'pagarme_configurations/transparent_payment_methods'
+        );
+    }
+
+    /**
      * @return string
      */
     private function getCreditcardTitleStoreConfig()

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -211,20 +211,6 @@ class PagarMe_CreditCard_Model_Creditcard extends PagarMe_Core_Model_AbstractPay
         $this->transaction = $transaction;
     }
 
-    /**
-     * @param type $quote
-     *
-     * @return bool
-     */
-    public function isAvailable($quote = null)
-    {
-        if (!parent::isAvailable($quote)) {
-            return false;
-        }
-
-        return $this->isTransparentCheckoutActiveStoreConfig();
-    }
-
    /**
     * Retrieve payment method title
     *

--- a/tests/acceptance/Helper/PagarMeSwitch.php
+++ b/tests/acceptance/Helper/PagarMeSwitch.php
@@ -26,6 +26,11 @@ trait PagarMeSwitch
             'payment/pagarme_configurations/transparent_active',
             true
         );
+
+        $this->changePagarmeSetting(
+            'payment/pagarme_configurations/transparent_payment_methods',
+            'pagarme_bowleto,pagarme_creditcard'
+        );
     }
 
     protected function disablePagarmeTransparent()

--- a/tests/unit/app/code/community/PagarMe/Bowleto/Model/PagarMe_Bowleto_Model_BoletoTest.php
+++ b/tests/unit/app/code/community/PagarMe/Bowleto/Model/PagarMe_Bowleto_Model_BoletoTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @author LeonamDias <leonam.pd@gmail.com>
+ * @package PHP
+ */
+
+use PagarMe\Sdk\Card\Card;
+use PagarMe\Sdk\Transaction\AbstractTransaction;
+use PagarMe\Sdk\Transaction\BoletoTransaction;
+use PagarMe_Bowleto_Model_Boleto as ModelBoleto;
+
+class PagarMeboletoModelBoletoTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function mustReturnFalseIfCheckoutTransparentIsInactive()
+    {
+        $boletoModel = $this
+            ->getMockBuilder('PagarMe_Bowleto_Model_Boleto')
+            ->setMethods([
+                'isTransparentCheckoutActive',
+                'getActiveTransparentPaymentMethod'
+            ])
+            ->getMock();
+
+        $boletoModel
+            ->expects($this->any())
+            ->method('isTransparentCheckoutActive')
+            ->willReturn(false);
+
+        $this->assertFalse(
+            $boletoModel->isAvailable(),
+            'Transparent checkout is inactive. Boleto should be unavailable'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mustReturnTrueIfBoletoIsEnabled()
+    {
+        $boletoModel = $this
+            ->getMockBuilder('PagarMe_Bowleto_Model_Boleto')
+            ->setMethods([
+                'isTransparentCheckoutActive',
+                'getActiveTransparentPaymentMethod'
+            ])
+            ->getMock();
+
+        $boletoModel
+            ->expects($this->any())
+            ->method('isTransparentCheckoutActive')
+            ->willReturn(true);
+
+        $boletoModel
+            ->expects($this->any())
+            ->method('getActiveTransparentPaymentMethod')
+            ->willReturn('pagarme_bowleto');
+
+            $this->assertTrue($boletoModel->isAvailable());
+    }
+
+    /**
+     * @test
+     */
+    public function mustReturnFalseIfBoletoIsDisabled()
+    {
+        $boletoModel = $this
+            ->getMockBuilder('PagarMe_Bowleto_Model_Boleto')
+            ->setMethods([
+                'isTransparentCheckoutActive',
+                'getActiveTransparentPaymentMethod'
+            ])
+            ->getMock();
+
+        $boletoModel
+            ->expects($this->any())
+            ->method('isTransparentCheckoutActive')
+            ->willReturn(true);
+
+        $boletoModel
+            ->expects($this->any())
+            ->method('getActiveTransparentPaymentMethod')
+            ->willReturn('pagarme_creditcard');
+
+        $this->assertFalse($boletoModel->isAvailable());
+    }
+
+    /**
+     * @test
+     */
+    public function mustReturnTrueIfCreditCardAndBoletoIsEnabled()
+    {
+        $boletoModel = $this
+            ->getMockBuilder('PagarMe_Bowleto_Model_Boleto')
+            ->setMethods([
+                'isTransparentCheckoutActive',
+                'getActiveTransparentPaymentMethod'
+            ])
+            ->getMock();
+
+        $boletoModel
+            ->expects($this->any())
+            ->method('isTransparentCheckoutActive')
+            ->willReturn(true);
+
+        $boletoModel
+            ->expects($this->any())
+            ->method('getActiveTransparentPaymentMethod')
+            ->willReturn('pagarme_creditcard,pagarme_bowleto');
+
+        $this->assertTrue($boletoModel->isAvailable());
+    }
+}

--- a/tests/unit/app/code/community/PagarMe/Bowleto/Model/PagarMe_Bowleto_Model_BoletoTest.php
+++ b/tests/unit/app/code/community/PagarMe/Bowleto/Model/PagarMe_Bowleto_Model_BoletoTest.php
@@ -58,7 +58,7 @@ class PagarMeboletoModelBoletoTest extends PHPUnit_Framework_TestCase
             ->method('getActiveTransparentPaymentMethod')
             ->willReturn('pagarme_bowleto');
 
-            $this->assertTrue($boletoModel->isAvailable());
+        $this->assertTrue($boletoModel->isAvailable());
     }
 
     /**

--- a/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
+++ b/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
@@ -26,6 +26,30 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param boolean $status
+     */
+    private function setupTransparentCheckout($status)
+    {
+        $value = $status === true ? 1 : 0;
+
+        Mage::getModel('core/config')
+            ->saveConfig('payment/pagarme_configurations/transparent_active', $value);
+
+        Mage::getModel('core/config')->cleanCache();
+    }
+
+    private function setPaymentMethodActive($paymentMethod)
+    {
+        Mage::getModel('core/config')
+            ->saveConfig(
+                'payment/pagarme_configurations/transparent_payment_methods',
+                $paymentMethod
+            );
+
+        Mage::getModel('core/config')->cleanCache();
+    }
+
+    /**
      * @test
      */
     public function mustBeAnInstanceOfPagarmeCreditCardModel()
@@ -210,5 +234,107 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($creditCardModel->transactionIsPaid());
         $creditCardModel->capture();
         $this->assertTrue($creditCardModel->transactionIsPaid());
+    }
+
+    /**
+     * @test
+     */
+    public function mustReturnFalseIfCheckoutTransparentIsInactive()
+    {
+        $creditCardModel = $this
+            ->getMockBuilder('PagarMe_CreditCard_Model_CreditCard')
+            ->setMethods([
+                'isTransparentCheckoutActive',
+                'getActiveTransparentPaymentMethod'
+            ])
+            ->getMock();
+
+        $creditCardModel
+            ->expects($this->any())
+            ->method('isTransparentCheckoutActive')
+            ->willReturn(false);
+
+        $this->assertFalse(
+            $creditCardModel->isAvailable(),
+            'Transparent checkout is inactive. Credit card should be unavailable'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mustReturnTrueIfCreditCardIsEnabled()
+    {
+        $creditCardModel = $this
+            ->getMockBuilder('PagarMe_CreditCard_Model_CreditCard')
+            ->setMethods([
+                'isTransparentCheckoutActive',
+                'getActiveTransparentPaymentMethod'
+            ])
+            ->getMock();
+
+        $creditCardModel
+            ->expects($this->any())
+            ->method('isTransparentCheckoutActive')
+            ->willReturn(true);
+
+        $creditCardModel
+            ->expects($this->any())
+            ->method('getActiveTransparentPaymentMethod')
+            ->willReturn('pagarme_creditcard');
+
+            $this->assertTrue($creditCardModel->isAvailable());
+    }
+
+    /**
+     * @test
+     */
+    public function mustReturnFalseIfCreditCardIsDisabled()
+    {
+        $creditCardModel = $this
+            ->getMockBuilder('PagarMe_CreditCard_Model_CreditCard')
+            ->setMethods([
+                'isTransparentCheckoutActive',
+                'getActiveTransparentPaymentMethod'
+            ])
+            ->getMock();
+
+        $creditCardModel
+            ->expects($this->any())
+            ->method('isTransparentCheckoutActive')
+            ->willReturn(true);
+
+        $creditCardModel
+            ->expects($this->any())
+            ->method('getActiveTransparentPaymentMethod')
+            ->willReturn('pagarme_boleto');
+
+        $this->assertFalse($creditCardModel->isAvailable());
+    }
+
+    /**
+     * @test
+     */
+    public function mustReturnTrueIfCreditCardAndBoletoIsEnabled()
+    {
+        $creditCardModel = $this
+            ->getMockBuilder('PagarMe_CreditCard_Model_CreditCard')
+            ->setMethods([
+                'isTransparentCheckoutActive',
+                'getActiveTransparentPaymentMethod'
+            ])
+            ->getMock();
+
+        $creditCardModel
+            ->expects($this->any())
+            ->method('isTransparentCheckoutActive')
+            ->willReturn(true);
+
+        $creditCardModel
+            ->expects($this->any())
+            ->method('getActiveTransparentPaymentMethod')
+            ->willReturn('pagarme_boleto,pagarme_creditcard');
+
+        $this->assertTrue($creditCardModel->isAvailable());
     }
 }

--- a/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
+++ b/tests/unit/app/code/community/PagarMe/CreditCard/Model/PagarMe_CreditCard_Model_CreditcardTest.php
@@ -38,6 +38,9 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
         Mage::getModel('core/config')->cleanCache();
     }
 
+    /**
+     * @param string $paymentMethod
+     */
     private function setPaymentMethodActive($paymentMethod)
     {
         Mage::getModel('core/config')
@@ -283,7 +286,7 @@ class PagarMeCreditCardModelCreditcardTest extends PHPUnit_Framework_TestCase
             ->method('getActiveTransparentPaymentMethod')
             ->willReturn('pagarme_creditcard');
 
-            $this->assertTrue($creditCardModel->isAvailable());
+        $this->assertTrue($creditCardModel->isAvailable());
     }
 
     /**


### PR DESCRIPTION
### Descrição

O módulo possui uma configuração que permite o lojista definir se vai utilizar, no checkout transparente, **Boleto e Cartão de crédit** ou somente um dos dois: **somente boleto** ou **somente cartão de crédito**. O problema é que essa configuração não estava sendo respeitada e esse PR corrige o problema.

### Número da Issue

Closes #398

### Testes Realizados

Unitários