### PR TITLE
checkout: fix #403 - string did not match pattern

### DIFF
--- a/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
@@ -97,17 +97,17 @@
                                         $installmentInfo['total_amount']
                                 );
                                 if ((int)$installmentNumber <= $this->getFreeInstallmentsConfig()) {
-                                  echo sprintf(
-                                    '%sx R$ %s (sem juros)',
-                                    $installmentNumber,
-                                    number_format($floatInstallmentAmount, 2, ",", ".")
+                                    echo sprintf(
+                                        '%sx R$ %s (sem juros)',
+                                        $installmentNumber,
+                                        number_format($floatInstallmentAmount, 2, ",", ".")
                                   );
                                 } else {
-                                  echo sprintf(
-                                    '%sx R$ %s (total R$ %s)',
-                                    $installmentNumber,
-                                    number_format($floatInstallmentAmount, 2, ",", "."),
-                                    number_format($floatInstallmentTotalAmount, 2, ",", ".")
+                                    echo sprintf(
+                                        '%sx R$ %s (total R$ %s)',
+                                        $installmentNumber,
+                                        number_format($floatInstallmentAmount, 2, ",", "."),
+                                        number_format($floatInstallmentTotalAmount, 2, ",", ".")
                                   );
                                 }
                             ?>
@@ -168,10 +168,10 @@
         form,
         container: '.card-wrapper',
         formSelectors: {
-            numberInput: 'input[id="pagarme_creditcard_creditcard_number"',
-            expiryInput: 'input[id="pagarme_creditcard_creditcard_expiration_date"',
-            cvcInput: 'input[id="pagarme_creditcard_creditcard_cvv"',
-            nameInput: 'input[id="pagarme_creditcard_creditcard_owner"'
+            numberInput: 'input[id="pagarme_creditcard_creditcard_number"]',
+            expiryInput: 'input[id="pagarme_creditcard_creditcard_expiration_date"]',
+            cvcInput: 'input[id="pagarme_creditcard_creditcard_cvv"]',
+            nameInput: 'input[id="pagarme_creditcard_creditcard_owner"]',
         },
 
         formatting: true,


### PR DESCRIPTION
### Descrição
Havia alguns seletores faltando o ']', o que causava erros devido no Safari devido à [intolerância a erro](https://www.reddit.com/r/firefox/comments/5nbmqi/on_handling_invalid_selector_strings/) de seletor dele.

<img src="https://ibin.co/4hPUBKgRGDMm.png">

### Número da Issue
#403 

### Testes Realizados
Simulado (tanto o erro quando a solução) no Epiphany 3.32 (e confirmado o funcionamento num Safari de 3° o qual desconheço a versão), numa loja rodando Magento 1.9.4.0 num server com PHP 7.2

@zitoloco @laund @IvanMicai @rsmelo @rafaelstz 