### PR TITLE
Corrige geração do card_hash

### DIFF
--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.18.2</version>
+            <version>3.18.3</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.18.2</version>
+            <version>3.18.3</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -264,9 +264,9 @@ class PagarMe_CreditCard_Model_Creditcard extends PagarMe_Core_Model_AbstractPay
     {
         if ($installments <= 0) {
             $message = $this->pagarmeCoreHelper->__(
-                'Please, select the number of installments'
+                'Please, select the number of installments.'
             );
-            throw new InvalidInstallmentsException($message . $installments);
+            throw new InvalidInstallmentsException($message);
         }
 
         if ($installments > self::PAGARME_MAX_INSTALLMENTS) {

--- a/app/code/community/PagarMe/CreditCard/Model/Quote/Address/Total/CreditCardInterestAmount.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Quote/Address/Total/CreditCardInterestAmount.php
@@ -48,9 +48,6 @@ class PagarMe_CreditCard_Model_Quote_Address_Total_CreditCardInterestAmount exte
                 $paymentMethodParameters
             );
 
-            $this->_addAmount($this->interestValue);
-            $this->_addBaseAmount($this->interestValue);
-
             $orderTotal = $address->getGrandTotal() + $this->interestValue;
             $address->setGrandTotal($orderTotal);
             $address->setBaseGrandTotal($orderTotal);

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -58,7 +58,7 @@
             <modules>
                 <PagarMe_CreditCard>
                     <files>
-                        <default>PagarMe_Creditcard.csv</default>
+                        <default>PagarMe_CreditCard.csv</default>
                     </files>
                 </PagarMe_CreditCard>
             </modules>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.18.2</version>
+            <version>3.18.3</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.18.2</version>
+            <version>3.18.3</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
@@ -18,7 +18,7 @@
                         type="text"
                         id="<?= $_code ?>_creditcard_number"
                         title="<?= $helper->__('Credit Card Number') ?>"
-                        class="input-text required-entry validate-alphanum-with-spaces"
+                        class="input-text required-entry validate-alphanum-with-spaces validate-card-number-length"
                         maxlength="23"
                         value=""
                     />
@@ -34,7 +34,7 @@
                         id="<?= $_code ?>_creditcard_owner"
                         placeholder="<?= $helper->__('Name in credit card') ?>"
                         title="<?= $helper->__('Credit Card Owner') ?>"
-                        class="input-text required-entry validate-alphanum-with-spaces"
+                        class="input-text required-entry validate-alphanum-with-spaces validate-card-holder-length"
                         value=""
                     />
                 </div>
@@ -64,7 +64,7 @@
                         type="text"
                         id="<?= $_code ?>_creditcard_cvv"
                         title="<?= $helper->__('Credit Card Verification Number') ?>"
-                        class="input-text required-entry validate-digits"
+                        class="input-text required-entry validate-digits validate-cvv-length"
                         maxlength="4"
                         value=""
                     />
@@ -79,7 +79,7 @@
                         name="payment[installments]"
                         id="<?= $_code ?>_creditcard_installments"
                         title="<?= $helper->__('Installments') ?>"
-                        class="input-text required-entry"
+                        class="input-text required-entry validate-installments"
                     >
                     <option value="0">
                       <?= Mage::helper('pagarme_core')->__('Please, select the number of installments'); ?>

--- a/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
@@ -124,6 +124,12 @@
     <?= $this->getMethod()->getConfigData('message');?>
 </div>
 <script type="text/javascript">
+Translator.add('Please, enter a valid expiration date. For example 12 / 25.', "<?php echo $helper->__('Please, enter a valid expiration date. For example 12 / 25.'); ?>");
+Translator.add('Please, enter a valid name.', "<?php echo $helper->__('Please, enter a valid name.'); ?>");
+Translator.add('Please, enter a valid credit card number.', "<?php echo $helper->__('Please, enter a valid credit card number.'); ?>");
+Translator.add('Please, enter a valid credit card verification number.', "<?php echo $helper->__('Please, enter a valid credit card verification number.'); ?>");
+Translator.add('Please, select the number of installments.', "<?php echo $helper->__('Please, select the number of installments.'); ?>");
+
 (function(window, document) {
 
   let generateCardHashEvent;

--- a/app/locale/pt_BR/PagarMe_CreditCard.csv
+++ b/app/locale/pt_BR/PagarMe_CreditCard.csv
@@ -1,8 +1,8 @@
 "Installments","Parcelas"
-"Installments number should be greater than zero","O número de parcelas deve ser maior que zero",
-"Installments number should be lower than Pagar.Me limit","O número de parcelas deve ser menor que o limite Pagar.me",
-"Installments number should not be greater than %d","O número de parcelas deve menor que %d",
-"Installments is Diverging","Valor de parcelas divergente",
+"Installments number should be greater than zero","O número de parcelas deve ser maior que zero"
+"Installments number should be lower than Pagar.Me limit","O número de parcelas deve ser menor que o limite Pagar.me"
+"Installments number should not be greater than %d","O número de parcelas deve menor que %d"
+"Installments is Diverging","Valor de parcelas divergente"
 "Installments related Interest","Juros do parcelamento"
 "Undefined Billing address: %s","Endereço de cobrança não informado"
 "Pagar.me Credit card","Cartão de crédito Pagar.me"
@@ -22,5 +22,11 @@
 "Captured amount of %s","Valor capturado: %s"
 "Payment refused.","Pagamento recusado."
 "Please, contact your bank for more informations.","Por favor, contate seu banco para mais informações."
-"Please, contact us for more informations.","Por favor, contate-nos para mais informações.",
+"Please, contact us for more informations.","Por favor, contate-nos para mais informações."
 "Card holder name","Nome do portador do cartão"
+"Please, select the number of installments","Por favor, selecione o número de parcelas."
+"Please, enter a valid credit card number.","Por favor, digite um número de cartão de crédito válido."
+"Please, enter a valid name.","Por favor, digite um nome válido."
+"Please, enter a valid expiration date. For example 12 / 25.","Por favor, digite uma data de expiração válida. Por exemplo 12 / 25."
+"Please, enter a valid credit card verification number.","Por favor, digite um código de verificação válido."
+"Please, select the number of installments.","Por favor, selecione o número de parcelas."

--- a/js/pagarme/creditcard.js
+++ b/js/pagarme/creditcard.js
@@ -56,9 +56,9 @@ const shouldGenerateCardHash = (card) => {
     card
   })
 
-  const { card_number, card_holder_name, card_cvv, card_expiration_date } = cardValidations.card
+  const { card_holder_name, card_cvv } = cardValidations.card
 
-  return card_number && card_holder_name && card_cvv && isValidCardExpirationDate()
+  return card_holder_name && card_cvv && isValidCardExpirationDate()
 }
 
 const tryGenerateCardHash = debounce(() => {

--- a/js/pagarme/validateInputs.js
+++ b/js/pagarme/validateInputs.js
@@ -3,7 +3,24 @@
  * 'MMYY', 'MM/YY', 'MM / YY'
  */
 const validDateRegex = new RegExp(/\d{2}\s?\/?\s?\d{2}/)
+const hasNumber = new RegExp(/\d+/)
 
-Validation.add('validate-card-expiration-date', 'Please enter a valid expiration date. For example 12 / 25', function(value) {
-    return validDateRegex.test(value)
+Validation.add('validate-card-expiration-date', 'Please enter a valid expiration date. For example 12 / 25.', function(value) {
+  return validDateRegex.test(value)
+})
+
+Validation.add('validate-card-holder-length', 'Please, enter a valid name.', function(value) {
+  return value.length >= 3 && !hasNumber.test(value)
+})
+
+Validation.add('validate-card-number-length', 'Please, enter a valid credit card number.', function(value) {
+  return value.length >= 10
+})
+
+Validation.add('validate-cvv-length', 'Please, enter a valid credit card verification number.', function(value) {
+  return value.length >= 3 && value.length <= 4
+})
+
+Validation.add('validate-installments', 'Please, select a valid installments number.', function(value) {
+  return value >= 1 && value <= 12
 })

--- a/js/pagarme/validateInputs.js
+++ b/js/pagarme/validateInputs.js
@@ -5,7 +5,7 @@
 const validDateRegex = new RegExp(/\d{2}\s?\/?\s?\d{2}/)
 const hasNumber = new RegExp(/\d+/)
 
-Validation.add('validate-card-expiration-date', 'Please enter a valid expiration date. For example 12 / 25.', function(value) {
+Validation.add('validate-card-expiration-date', 'Please, enter a valid expiration date. For example 12 / 25.', function(value) {
   return validDateRegex.test(value)
 })
 
@@ -21,6 +21,6 @@ Validation.add('validate-cvv-length', 'Please, enter a valid credit card verific
   return value.length >= 3 && value.length <= 4
 })
 
-Validation.add('validate-installments', 'Please, select a valid installments number.', function(value) {
+Validation.add('validate-installments', 'Please, select the number of installments.', function(value) {
   return value >= 1 && value <= 12
 })

--- a/tests/acceptance/features/credit_card.feature
+++ b/tests/acceptance/features/credit_card.feature
@@ -50,8 +50,8 @@ Feature: Credit Card
         And login with registered user
         And confirm billing and shipping address information
         And choose pay with transparent checkout using credit card
-        And I give a invalid payment information
         And I choose 1
+        And I give a invalid payment information
         And place order
         Then the purchase must be paid with success
         And I get the created order id from success page


### PR DESCRIPTION
### Descrição

## Card Hash
O `pagarme-js` não valida alguns BINs, e não temos como fazer a validação correta atualmente. Esse PR remove a necessidade de o número do cartão estar correto perante o `pagarme-js` na hora de gerar o card_hash. 

Comportamento anterior:

Caso o cartão não fosse validado perante o `pagarme-js`, o card_hash não era gerado, e era disparado o erro:
"Nome do portador está faltando",
"Data de expiração está faltando",
"Número do cartão está faltando"

Mesmo que todos esses campos estivessem preenchidos.

No novo fluxo ficará assim:

O card_hash será gerado, e caso os dados de cartão estejam incorretos a transação será recusada.

Este PR também insere mensagens de erro, para auxiliar o usuário à digitar os campos corretamente, como mostra a imagem abaixo:

![image](https://user-images.githubusercontent.com/18074134/58441441-98f45d00-80b8-11e9-9820-8648e8efa925.png)

## Taxa de juros

O juros estava sendo exibido errado em alguns cenários, cobrando do comprador um valor maior do que o calculado.

Esse PR também corrige esse problema.

### Número da Issue

#415 

### Testes Realizados

Testes manuais, pois os testes automaticos já cobrem esses cenários
