### PR TITLE
checkout: corrige erro de card_hash quando um campo anterior é atualizado

### DIFF
--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.20.0</version>
+            <version>3.20.1</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.20.0</version>
+            <version>3.20.1</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.20.0</version>
+            <version>3.20.1</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.20.0</version>
+            <version>3.20.1</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
@@ -132,14 +132,8 @@ Translator.add('Please, select the number of installments.', "<?php echo $helper
 
 (function(window, document) {
 
-  let generateCardHashEvent;
-
-  if (!generateCardHashEvent) {
-    const pagarmeDiv = get('#payment_form_pagarme_creditcard')
-    pagarmeDiv.addEventListener('keyup', tryGenerateCardHash)
-
-    generateCardHashEvent = true;
-  }
+  let generateCardHashEvent = false
+  let card
 
   const findParentForm = node => {
     if (node.tagName === 'FORM') return node
@@ -147,9 +141,18 @@ Translator.add('Please, select the number of installments.', "<?php echo $helper
     return findParentForm(node.parentNode)
   }
 
+  const paymentDiv = document.querySelector('#payment_form_pagarme_creditcard')
+  const checkoutForm = findParentForm(paymentDiv)
+
+  if (!generateCardHashEvent) {
+    checkoutForm.addEventListener('input', tryGenerateCardHash)
+
+    generateCardHashEvent = true
+  }
+
   const loadCardScript = () => {
     let cardScript = document.createElement('script');
-    cardScript.setAttribute('src','https://s3.amazonaws.com/card.prd.pagarme.net/card.js');
+    cardScript.setAttribute('src', 'https://s3.amazonaws.com/card.prd.pagarme.net/card.js')
     cardScript.setAttribute('id', 'cardScript')
 
     document.body.appendChild(cardScript)
@@ -157,21 +160,15 @@ Translator.add('Please, select the number of installments.', "<?php echo $helper
     cardScript.addEventListener('load', createCard)
   }
 
-  let card
-
   const createCard = () => {
     if (!card) {
-      const paymentDiv = document.querySelector('#payment_form_pagarme_creditcard')
-
       if (paymentDiv.parentElement.getWidth() < 600) {
         const cardDataDiv = document.querySelector('.card-data')
-
         cardDataDiv.addClassName('card-data-column')
       }
 
-      const form = findParentForm(paymentDiv)
       card = new Card({
-        form,
+        form: checkoutForm,
         container: '.card-wrapper',
         formSelectors: {
             numberInput: 'input[id="pagarme_creditcard_creditcard_number"]',


### PR DESCRIPTION
### Descrição

Atualmente, se esse fluxo for seguido, um erro de `card_hash inválido` será lançado:

1. Preencha seus dados de endereço, com algo errado. Ex: Telefone `1192832`
2. Preencha os dados do cartão e finalize a compra.
3. Será lançado o erro de `Número de telefone inválido
4. Corrija os dados de telefone. Ex: `11912345678`
5. Finalize a compra. Será lançado o erro de `card_hash inválido`

Esse erro ocorre pois o `card_hash` não está sendo gerado novamente quando o campo de telefone é atualizado. Ele é gerado apenas quando os dados de cartão são editados.

Esse PR corrige esse problema, fazendo com que o `card_hash` tente ser gerado sempre que algum dado do formulário for editado.

### Número da Issue

Resolves #415 
