### PR TITLE
pagarme-js: update to version 4.4

### DIFF
--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.20.1</version>
+            <version>3.20.2</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.20.1</version>
+            <version>3.20.2</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.20.1</version>
+            <version>3.20.2</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.20.1</version>
+            <version>3.20.2</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
+++ b/app/design/frontend/base/default/layout/pagarme/pagarme_creditcard.xml
@@ -4,7 +4,7 @@
         <reference name="head">
             <block type="core/text" name="pagarme.cdn.js">
                 <action method="setText">
-                    <text><![CDATA[<script src="https://assets.pagar.me/pagarme-js/3.0/pagarme.min.js"></script>]]></text>
+                    <text><![CDATA[<script src="https://assets.pagar.me/pagarme-js/4.4/pagarme.min.js"></script>]]></text>
                 </action>
             </block>
         </reference>


### PR DESCRIPTION
### Descrição

Atualiza a biblioteca do pagarme-js, usufruindo de novas features e corrigindo alguns problemas.

O principal foco dessa atualização é corrigir os recentes problemas causados por cartões de crédito `mastercard` que possuem BIN iniciado em 2.

Caso ocorra uma tentativa de criação de pedido utilizando um cartão master com BIN iniciado em 2, ocorrerá um erro ao gerar o `card_hash`, e a atualização da biblioteca corrige isso.

### Número da Issue

Sem issue

### Testes Realizados

Testes manuais.