### PR TITLE
order totals: avoid call on null

### DIFF
--- a/app/code/community/PagarMe/CreditCard/Block/Sales/RateAmount.php
+++ b/app/code/community/PagarMe/CreditCard/Block/Sales/RateAmount.php
@@ -42,7 +42,13 @@ class PagarMe_CreditCard_Block_Sales_RateAmount extends Mage_Core_Block_Abstract
 
     protected function shouldShowTotal()
     {
-        $paymentIsPagarMeCreditcard = $this->getReferencedOrder()->getPayment()->getMethod() ==
+        $referencedOrder = $this->getReferencedOrder();
+
+        if (is_null($referencedOrder)) {
+            return false;
+        }
+
+        $paymentIsPagarMeCreditcard = $referencedOrder->getPayment()->getMethod() ==
             PagarMe_CreditCard_Model_Creditcard::PAGARME_CREDITCARD;
 
         $rateAmount = $this->getRateAmount();

--- a/app/code/community/PagarMe/Modal/Block/Sales/RateAmount.php
+++ b/app/code/community/PagarMe/Modal/Block/Sales/RateAmount.php
@@ -44,7 +44,13 @@ class PagarMe_Modal_Block_Sales_RateAmount extends Mage_Core_Block_Abstract
 
     private function shouldShowTotal()
     {
-        $paymentIsPagarMeCreditcard = $this->getReferencedOrder()->getPayment()->getMethod() ==
+        $referencedOrder = $this->getReferencedOrder();
+
+        if (is_null($referencedOrder)) {
+            return false;
+        }
+
+        $paymentIsPagarMeCreditcard = $referencedOrder->getPayment()->getMethod() ==
             PagarMe_Modal_Model_Modal::PAGARME_MODAL;
 
         $rateAmount = $this->getRateAmount();


### PR DESCRIPTION
### Descrição

Valida se existe alguma `order` relacionada antes de validar se o método de pagamento é do Pagar.me

### Número da Issue

#431

### Testes Realizados

Não foi possível realizar testes com outros módulos de meio de pagamento.