### PR TITLE
Automatiza a criação de releases do projeto via Circle-CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,55 @@ jobs:
             make show-system-logs
             make show-exception-logs
 
+  build-release-artifact:
+    machine:
+      enabled: true
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: "Build artifact to be released"
+          command: |
+            chmod +x ~/project/script/build-artifact.sh
+            make build-release-artifact
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+              - ./
+
+  publish-release-github:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: "Publish Release on Github"
+          command: |
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./build/
+
 workflows:
   version: 2
+  release:
+    jobs:
+      - checkout-code:
+          filters:
+            tags:
+              only: /^v.*$/
+      - build-release-artifact:
+          requires:
+          - checkout-code
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+      - publish-release-github:
+          requires:
+            - build-release-artifact
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
   tests:
     jobs:
       - checkout-code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           name: "Build artifact to be released"
           command: |
             chmod +x ~/project/script/build-artifact.sh
-            make build-release-artifact
+            make build-release-artifact RELEASE_TAG=${CIRCLE_TAG}
       - persist_to_workspace:
           root: ~/project
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,12 +131,16 @@ workflows:
     jobs:
       - checkout-code:
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v.*$/
       - build-release-artifact:
           requires:
           - checkout-code
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+$/
       - publish-release-github:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ test-e2e-suite: wait-for-magento
 composer-install:
 	@docker-compose run composer install
 
+build-release-artifact:
+	@./script/build-artifact.sh
+
 toggle-mage-logs:
 	@docker-compose exec magento vendor/bin/n98-magerun dev:log
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ composer-install:
 	@docker-compose run composer install
 
 build-release-artifact:
-	@./script/build-artifact.sh
+	@./script/build-artifact.sh $(RELEASE_TAG)
 
 toggle-mage-logs:
 	@docker-compose exec magento vendor/bin/n98-magerun dev:log

--- a/script/build-artifact.sh
+++ b/script/build-artifact.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+rm -rf ./vendor ./build
+echo "Installing project (no-dev) dependencies..."
+docker-compose run composer install --no-dev
+
+echo "Creating zip file from source code and its dependencies..."
+docker-compose run composer archive --file=pagarme-magento --format=zip --dir=./build
+
+exit 0

--- a/script/build-artifact.sh
+++ b/script/build-artifact.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
+if [ "$1" == "" ]; then
+    echo "There's no Git tag defined to build the artifact"
+    exit 1
+fi
+
+RELEASE_TAG=$1
+ARTIFACT_FILE_NAME="pagarme-magento-$RELEASE_TAG"
+
 rm -rf ./vendor ./build
 echo "Installing project (no-dev) dependencies..."
 docker-compose run composer install --no-dev
 
 echo "Creating zip file from source code and its dependencies..."
-docker-compose run composer archive --file=pagarme-magento --format=zip --dir=./build
+docker-compose run composer archive --file=$ARTIFACT_FILE_NAME --format=zip --dir=./build
 
 exit 0


### PR DESCRIPTION
### Descrição

O processo de publicação de releases no projeto é bem manual e suscetível a erros. Esse PR tem por objetivo automatizar esse processo via Circle-Ci. A implementação foi feita utilizando o [ghr](https://github.com/tcnksm/ghr) e baseada no [tutorial do próprio Circle-Ci](https://circleci.com/blog/publishing-to-github-releases-via-circleci/)

#### Como funciona?

1. Todo o fluxo está baseado em tags do git. Elas devem seguir o formato `v\d+.\d+.\d+`. Ex: `v3.2.25`.
2. Uma vez feito o _push_ da tag no repositório, o circle-ci iniciará o processo de build e publicação do novo release no Github.
3. Dado o build gerado no passo anterior, via `ghr`, é feito a publicação de um novo release no repositório.


#### O fluxo de build

1. Antes de tudo, executo um script bash para:
1.1 remover o diretório `vendor` e `build` se houverem. Isso garante que de fato pacote não terá conflitos de versão.
2. instala as dependências (`no-dev`) do projeto com `composer install`
3. gera um arquivo zip do projeto com `composer archive`.

### Dependências

Para que todo o fluxo de publicação funcione é necessário inserir um [Github token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) para que o ghr tenha o acesso necessário (basta permitir acesso somente ao item `repo` das configurações do token) para a publicação.

Uma vez gerado o token, basta adicioná-lo no Circle-Ci do projeto como variável de ambiente. O nome da variável deve ser `GITHUB_TOKEN`.

_uma vez foca, sempre macaco :heart:_

### Número da Issue

Não há.

### Testes Realizados

Testes manuais do fluxo implementado.
