### PR TITLE
Fix wrong interest rate exhibition

### DIFF
--- a/app/code/community/PagarMe/CreditCard/Block/Form/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Block/Form/Creditcard.php
@@ -70,11 +70,4 @@ class PagarMe_Creditcard_Block_Form_CreditCard extends Mage_Payment_Block_Form_C
     public function getFreeInstallmentsConfig() {
         return $this->getFreeInstallmentStoreConfig();
     }
-
-    /**
-     * @return float
-     */
-    public function getInterestRateStoreConfig() {
-      return $this->getFreeInstallmentStoreConfig();
-  }
 }


### PR DESCRIPTION
### Descrição

Esse PR visa corrigir a exibição incorreta do juros adicionado as parcelas. Quando foi realizada a alteração da exibição das parcelas no checkout transparente, um dos métodos adicionados não era necessário, esse método visa remover esse método

### Número da Issue

Não há.

### Testes Realizados

Foram realizadas validações no frontend Magento 1.8.1.0 uma vez que se tratava de um erro de exibição
