### PR TITLE
Enviar e-mail para o cliente ao faturar o pedido

### DIFF
--- a/app/code/community/PagarMe/Core/Model/Postback.php
+++ b/app/code/community/PagarMe/Core/Model/Postback.php
@@ -129,15 +129,13 @@ class PagarMe_Core_Model_Postback extends Mage_Core_Model_Abstract
      */
     public function setOrderAsPaid($order)
     {
-        $invoice = $this->getInvoiceService()
-            ->createInvoiceFromOrder($order);
+        $invoice = $this->getInvoiceService()->createInvoiceFromOrder($order);
+        $invoice->register()->pay();
 
-        $invoice->register()
-            ->pay();
+        $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, true, 'pago', true);
+        $invoice->sendEmail();
 
-        $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, true, "pago");
-
-        $transactionSave = Mage::getModel('core/resource_transaction')
+        Mage::getModel('core/resource_transaction')
             ->addObject($order)
             ->addObject($invoice)
             ->save();
@@ -153,11 +151,12 @@ class PagarMe_Core_Model_Postback extends Mage_Core_Model_Abstract
     public function setOrderAsAuthorized($order)
     {
         $order->setState(
-            Mage_Sales_Model_Order::STATE_PROCESSING, 
-            true, 
+            Mage_Sales_Model_Order::STATE_PROCESSING,
+            true,
             Mage::helper('sales')->__(
-                'Authorized amount of %s.', 
-                substr('R$'.$order->getGrandTotal(), 0, -2))
+                'Authorized amount of %s.',
+                substr('R$'.$order->getGrandTotal(), 0, -2)
+            )
         );
 
         $transactionSave = Mage::getModel('core/resource_transaction')


### PR DESCRIPTION
### Descrição
Ao faturar pedidos feitos no boleto, os clientes não estavam sendo notificados por e-mail.

### Número da Issue
Foi tratado diretamente por e-mail com o Matheus Maciel.

### Testes Realizados
Criado pedido no boleto e simulado o faturamento usando `Mage::getModel('pagarme_core/postback')->setOrderAsPaid(Mage::getModel('sales/order')->load($orderId))` antes e depois dessa alteração.

Antes:
![image](https://user-images.githubusercontent.com/4603111/72996719-ebb61e00-3dd9-11ea-8d1f-17a2253ef5b9.png)

Agora:
![image](https://user-images.githubusercontent.com/4603111/72996542-aeea2700-3dd9-11ea-850d-24aaf1636583.png)

Testes executados numa instalação do Magento 1.9.4 em ambos PHP 7.2 e 7.3.

@zitoloco @laund @IvanMicai @jvrmaia @rsmelo 