### PR TITLE
Corrigida discriminação de desconto nos totais do pedido

### DIFF
--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -24,7 +24,7 @@
             <quote>
                 <totals>
                     <pagarme_creditcard_interest>
-                        <after>grand_total</after>
+                        <before>grand_total</before>
                         <class>pagarme_creditcard/quote_address_total_creditCardInterestAmount</class>
                     </pagarme_creditcard_interest>
                 </totals>


### PR DESCRIPTION
### Descrição

Notamos que após a instalação do módulo de vocês os descontos deixaram de ser exibidos nos totais dos pedidos (mesmo os que não foram feitos usando um método do módulo), ficando uma discrepância na soma:

![image](https://user-images.githubusercontent.com/4603111/79226794-543ef500-7e35-11ea-91a0-7424444375a2.png)

### Testes Realizados

Simplesmente fizemos um novo pedido de forma idêntica e checamos os totais novamente após a alteração:

![image](https://user-images.githubusercontent.com/4603111/79227298-0e366100-7e36-11ea-9c8b-415595c15c03.png)

### Detalhes técnicos:
Módulo v3.22.0 / Magento 1.9.4.1 / testado em ambos PHP 7.2 e 7.4

### Disclaimer
Infelizmente a correção só passa a valer para pedidos feitos após ela ter sido aplicada (pedidos já existentes continuam com a discriminação do desconto faltando).

@sdoblinski @zitoloco @IvanMicai @jvrmaia @rsmelo 