### PR TITLE
Corrige postback do status analyzing / pending_review para paid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: up-containers composer-install tailf-magento-logs toggle-mage-logs enable-mage-errors
+default: up-containers composer-install toggle-mage-logs enable-mage-errors tailf-magento-logs
 
 wait-for-magento:
 	@./script/wait-for-magento.sh

--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.22.0</version>
+            <version>3.22.1</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/Model/PostbackHandler/Analyzing.php
+++ b/app/code/community/PagarMe/Core/Model/PostbackHandler/Analyzing.php
@@ -5,7 +5,7 @@ use \PagarMe\Sdk\Transaction\AbstractTransaction;
 class PagarMe_Core_Model_PostbackHandler_Analyzing extends PagarMe_Core_Model_PostbackHandler_Base
 {
     const MAGENTO_DESIRED_STATUS = Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW;
-   
+
     /**
      * Returns the desired state on magento
      *
@@ -22,7 +22,10 @@ class PagarMe_Core_Model_PostbackHandler_Analyzing extends PagarMe_Core_Model_Po
     public function process()
     {
         $this->order->setState(
-            self::MAGENTO_DESIRED_STATUS
+            self::MAGENTO_DESIRED_STATUS,
+            true,
+            Mage::helper('pagarme_core')
+                ->__('Transaction waiting for antifraud analysis')
         );
 
         Mage::getModel('core/resource_transaction')

--- a/app/code/community/PagarMe/Core/Model/PostbackHandler/Factory.php
+++ b/app/code/community/PagarMe/Core/Model/PostbackHandler/Factory.php
@@ -61,6 +61,14 @@ class PagarMe_Core_Model_PostbackHandler_Factory
             );
         }
 
+        if ($status === AbstractTransaction::PENDING_REVIEW) {
+            return new PagarMe_Core_Model_PostbackHandler_PendingReview(
+              $order,
+              $transactionId,
+              $oldStatus
+            );
+        }
+
         throw new \Exception(sprintf(
             'There\'s no postback handler for this desired status: %s',
             $status

--- a/app/code/community/PagarMe/Core/Model/PostbackHandler/PendingReview.php
+++ b/app/code/community/PagarMe/Core/Model/PostbackHandler/PendingReview.php
@@ -1,0 +1,37 @@
+<?php
+
+use \PagarMe\Sdk\Transaction\AbstractTransaction;
+
+class PagarMe_Core_Model_PostbackHandler_PendingReview extends PagarMe_Core_Model_PostbackHandler_Base
+{
+    const MAGENTO_DESIRED_STATUS = Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW;
+
+    /**
+     * Returns the desired state on magento
+     *
+     * @return string
+     */
+    public function getDesiredState()
+    {
+        return self::MAGENTO_DESIRED_STATUS;
+    }
+
+    /**
+     * @return \Mage_Sales_Model_Order
+     */
+    public function process()
+    {
+        $this->order->setState(
+            self::MAGENTO_DESIRED_STATUS,
+            true,
+            Mage::helper('pagarme_core')
+                ->__('Waiting transaction review on Pagar.me Dashboard')
+        );
+
+        Mage::getModel('core/resource_transaction')
+            ->addObject($this->order)
+            ->save();
+
+        return $this->order;
+    }
+}

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.22.0</version>
+            <version>3.22.1</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
+++ b/app/code/community/PagarMe/CreditCard/Model/Creditcard.php
@@ -494,10 +494,7 @@ class PagarMe_CreditCard_Model_Creditcard extends PagarMe_Core_Model_AbstractPay
                 );
                 break;
             case AbstractTransaction::PENDING_REVIEW:
-                $message = sprintf(
-                    "%s",
-                    'Waiting transaction review on Pagar.me\'s Dashboard'
-                );
+                $message = 'Waiting transaction review on Pagar.me Dashboard';
                 $desiredStatus = Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW;
                 break;
             case AbstractTransaction::ANALYZING:

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.22.0</version>
+            <version>3.22.1</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.22.0</version>
+            <version>3.22.1</version>
         </PagarMe_Modal>
     </modules>
     <global>

--- a/app/locale/pt_BR/PagarMe_Core.csv
+++ b/app/locale/pt_BR/PagarMe_Core.csv
@@ -60,4 +60,5 @@
 "Minimum Installment Value","Valor mínimo por parcela"
 "Example 5.99","Exemplo 5.00"
 "Please, select the number of installments","Por favor, selecione o número de parcelas"
+"Transaction waiting for antifraud analysis","Aguardando análise do antifraude"
 "Waiting transaction review on Pagar.me Dashboard","Aguardando revisão da transação na dashboard Pagar.me"

--- a/app/locale/pt_BR/PagarMe_Core.csv
+++ b/app/locale/pt_BR/PagarMe_Core.csv
@@ -60,3 +60,4 @@
 "Minimum Installment Value","Valor mínimo por parcela"
 "Example 5.99","Exemplo 5.00"
 "Please, select the number of installments","Por favor, selecione o número de parcelas"
+"Waiting transaction review on Pagar.me Dashboard","Aguardando revisão da transação na dashboard Pagar.me"

--- a/tests/acceptance/Helper/PostbackDataProvider.php
+++ b/tests/acceptance/Helper/PostbackDataProvider.php
@@ -171,7 +171,7 @@ trait PostbackDataProvider
         return [
             'card_number' => '4111111111111111',
             'card_holder_name' => 'Ricardo Ledo',
-            'card_expiration_date' => '0220',
+            'card_expiration_date' => '0230',
             'card_cvv' => '231'
         ];
     }

--- a/tests/acceptance/PostbackContext.php
+++ b/tests/acceptance/PostbackContext.php
@@ -163,7 +163,7 @@ class PostbackContext extends MinkContext
 
         \PHPUnit_Framework_TestCase::assertEquals(
             $status,
-            $order->getStatus()
+            $order->getState()
         );
     }
 


### PR DESCRIPTION
### Descrição

Corrige o problema relatado na issue #452.

O de status `paid` não era tratado corretamente quando o status antigo era `analyzing` ou `pending_review`, devido à este [trecho de código](https://github.com/pagarme/pagarme-magento/blob/97c2e5c319192ea63f698c23bd09b5c1e0eeda4a/app/code/community/PagarMe/Core/Model/PostbackHandler/Paid.php#L45)

No comportamento implementado, o fluxo de status do pedido ficará dessa maneira:
![image](https://user-images.githubusercontent.com/18074134/81442210-9106bf00-9149-11ea-8a02-8902754e80ea.png)

### Número da Issue

#452 

### Testes Realizados

Testes de QA