### PR TITLE
postback: fix analyzing / pending review > refused

### DIFF
--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.22.1</version>
+            <version>3.22.2</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/Model/OrderStatusHandler/Canceled.php
+++ b/app/code/community/PagarMe/Core/Model/OrderStatusHandler/Canceled.php
@@ -54,6 +54,20 @@ class PagarMe_Core_Model_OrderStatusHandler_Canceled extends BaseHandler
         );
 
         try {
+            if ($this->order->getState() === Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW) {
+                /**
+                 * Cannot cancel order's with Payment Review State.
+                 * So we move the order to Pending Payment before cancel it.
+                 */
+                $this->order->setState(
+                    Mage_Sales_Model_Order::STATE_PENDING_PAYMENT,
+                    false,
+                    Mage::helper('pagarme_core')
+                        ->__('Review finished. Cancelling the order.'),
+                    false
+                );
+            }
+
             $this->cancel();
             $magentoTransaction->addObject($this->order)->save();
 

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.22.1</version>
+            <version>3.22.2</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.22.1</version>
+            <version>3.22.2</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.22.1</version>
+            <version>3.22.2</version>
         </PagarMe_Modal>
     </modules>
     <global>


### PR DESCRIPTION
### Descrição

Ao receber um Postback com _status_ refused, se o _state_ do pedido for `payment review`, ele será movido para `pending payment` antes de cancelar o pedido.

Isso precisa ser feito por conta dessa trava do magento:

https://github.com/laurentlepee/magento-ce-1.9.2.4/blob/master/app/code/core/Mage/Sales/Model/Order.php#L550

O histórico de status ficará dessa maneira:

![image](https://user-images.githubusercontent.com/18074134/83077773-848dcc00-a04e-11ea-8848-30e91c3898ac.png)

Nota: o texto `Review finished. Cancelling the order.` não precisa de tradução pois não será exibido em nenhum lugar.

### Número da Issue

Sem issue

### Testes Realizados

Testes manuais de postback, com os status:
`analyzing` > `refused`
`pending review` > `refused`
`processing` > `refused`
