### PR TITLE
Padronização dos headers X-PagarMe-User-Agent e X-PagarMe-Version

### DIFF
--- a/app/code/community/PagarMe/Bowleto/etc/config.xml
+++ b/app/code/community/PagarMe/Bowleto/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Bowleto>
-            <version>3.22.3</version>
+            <version>3.22.4</version>
         </PagarMe_Bowleto>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Core/Model/Sdk/Adapter.php
+++ b/app/code/community/PagarMe/Core/Model/Sdk/Adapter.php
@@ -42,15 +42,15 @@ class PagarMe_Core_Model_Sdk_Adapter extends Mage_Core_Model_Abstract
     public function getUserAgent()
     {
         $userAgentValue = sprintf(
-            'Magento/%s PagarMe/%s PHP/%s',
-            Mage::getVersion(),
+            'pagarme-magento/%s magento/%s',            
             Mage::getConfig()->getNode()->modules->PagarMe_Core->version,
-            phpversion()
+            Mage::getVersion()
         );
 
         return [
             'User-Agent' => $userAgentValue,
-            'X-PagarMe-User-Agent' => $userAgentValue
+            'X-PagarMe-User-Agent' => $userAgentValue,
+            'X-PagarMe-Version' => '2017-07-17'
         ];
     }
 }

--- a/app/code/community/PagarMe/Core/etc/config.xml
+++ b/app/code/community/PagarMe/Core/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Core>
-            <version>3.22.3</version>
+            <version>3.22.4</version>
         </PagarMe_Core>
     </modules>
     <global>

--- a/app/code/community/PagarMe/CreditCard/etc/config.xml
+++ b/app/code/community/PagarMe/CreditCard/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_CreditCard>
-            <version>3.22.3</version>
+            <version>3.22.4</version>
         </PagarMe_CreditCard>
     </modules>
     <global>

--- a/app/code/community/PagarMe/Modal/etc/config.xml
+++ b/app/code/community/PagarMe/Modal/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <PagarMe_Modal>
-            <version>3.22.3</version>
+            <version>3.22.4</version>
         </PagarMe_Modal>
     </modules>
     <global>


### PR DESCRIPTION
Esse PR tem o intuito de ajudar em 2 questões relacionadas aos headers:
- Reduzir demandas, problemas e dúvidas de clientes que estão iniciando a utilização do módulo, por ele funcionar na versão 2 da API da Pagar.me (2017-07-17) e novos cadastros serem criados automaticamente na versão mais atual da API - que atualmente é a versão 4 (2019-09-01). Para isso, será enviado o parâmetro **X-PagarMe-Version = 2017-07-17**, forçando sempre o uso da v2.
- Melhorar a possibilidade de monitorar o uso de nossos módulos de plataformas, padronizando o header X-PagarMe-User-Agent. Além dos ajustes no texto, foi removida a versão do PHP, pois essa foi adicionada no SDK de PHP através [desse PR](https://github.com/pagarme/pagarme-php/pull/371).