### PR TITLE
Correção de compatibilidade com checkouts personalizados

### DIFF
--- a/app/design/adminhtml/default/default/layout/pagarme/pagarme_modal.xml
+++ b/app/design/adminhtml/default/default/layout/pagarme/pagarme_modal.xml
@@ -2,8 +2,8 @@
 <layout>
     <default>
         <reference name="head">
-            <block type="core/text" name="pagarme.cdn.js.checkout" ifconfig="payment/pagarme_configurations/modal_active">
-                <action method="setText">
+            <block type="core/text" name="pagarme.cdn.js.checkout">
+                <action method="setText" ifconfig="payment/pagarme_configurations/modal_active">
                     <text><![CDATA[<script src="https://assets.pagar.me/checkout/checkout.js" type="text/javascript"></script>]]></text>
                 </action>
             </block>

--- a/app/design/frontend/base/default/layout/pagarme/pagarme_modal.xml
+++ b/app/design/frontend/base/default/layout/pagarme/pagarme_modal.xml
@@ -2,8 +2,8 @@
 <layout>
     <default>
         <reference name="head">
-            <block type="core/text" name="pagarme.cdn.js.checkout" ifconfig="payment/pagarme_configurations/modal_active">
-                <action method="setText">
+            <block type="core/text" name="pagarme.cdn.js.checkout">
+                <action method="setText" ifconfig="payment/pagarme_configurations/modal_active">
                     <text><![CDATA[<script src="https://assets.pagar.me/checkout/checkout.js" type="text/javascript"></script>]]></text>
                 </action>
             </block>


### PR DESCRIPTION
### Descrição
Notamos alguns bugs no checkout de nossas lojas que fazem uso do [OSC 6 Pro](https://onestepcheckout.com.br), e ao investigarmos com calma vimos que era devido a essa config do módulo de vocês não estar sendo respeitada:

![image](https://user-images.githubusercontent.com/4603111/93136307-0feca500-f6b2-11ea-8a20-c3e0f6cfec4c.png)

Fazendo o script https://assets.pagar.me/checkout/checkout.js ser carregado desnecessariamente, o que de tabela quebrava  o script de checkout da loja. Ao corrigirmos esse import a incompatibilidade deixou de ocorrer :)

### Testes Realizados
Verificamos o source da página de checkout antes e depois dessa alteração para assegurar que o script em questão só estivesse sendo incluso quando a configuração mencionada acima estivesse habilitada.

@zitoloco @jvrmaia @ftosta @rafaelstz @jonatasnona 
