### PR TITLE
Evita erros de Javascript ao utilizar configurações de minificação de arquivos

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Você pode acessar as demais instruções de configuração clicando [aqui](http
 
 Pedidos que forem criados na plataforma com boleto como forma de pagamento,
 deverão ser cancelados após o vencimento. O módulo possui um processo
-automatizado que, identifica os boletos pendentes e, se em **4** dias após a
+automatizado que, identifica os boletos pendentes e, se em **7** dias após a
 data de vencimento não houver o pagamento, o pedido é **cancelado**.
 
 Para que este processo funcione é preciso que as a _cron_ da plataforma seja

--- a/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
+++ b/app/design/frontend/base/default/template/pagarme/form/credit_card.phtml
@@ -124,16 +124,16 @@
     <?= $this->getMethod()->getConfigData('message');?>
 </div>
 <script type="text/javascript">
-Translator.add('Please, enter a valid expiration date. For example 12 / 25.', "<?php echo $helper->__('Please, enter a valid expiration date. For example 12 / 25.'); ?>");
-Translator.add('Please, enter a valid name.', "<?php echo $helper->__('Please, enter a valid name.'); ?>");
-Translator.add('Please, enter a valid credit card number.', "<?php echo $helper->__('Please, enter a valid credit card number.'); ?>");
-Translator.add('Please, enter a valid credit card verification number.', "<?php echo $helper->__('Please, enter a valid credit card verification number.'); ?>");
-Translator.add('Please, select the number of installments.', "<?php echo $helper->__('Please, select the number of installments.'); ?>");
-Translator.add('Please use only letters (a-z or A-Z), numbers (0-9) or spaces only in this field.', "<?php echo $helper->__('Please use only letters (a-z or A-Z), numbers (0-9) or spaces only in this field.'); ?>");
-Translator.add('This is a required field.', "<?php echo $helper->__('This is a required field.') ?>")
-Translator.add('Please use numbers only in this field. Please avoid spaces or other characters such as dots or commas.', "<?php echo $helper->__('Please use numbers only in this field. Please avoid spaces or other characters such as dots or commas.') ?>")
-
 (function(window, document) {
+
+  Translator.add('Please, enter a valid expiration date. For example 12 / 25.', "<?php echo $helper->__('Please, enter a valid expiration date. For example 12 / 25.'); ?>");
+  Translator.add('Please, enter a valid name.', "<?php echo $helper->__('Please, enter a valid name.'); ?>");
+  Translator.add('Please, enter a valid credit card number.', "<?php echo $helper->__('Please, enter a valid credit card number.'); ?>");
+  Translator.add('Please, enter a valid credit card verification number.', "<?php echo $helper->__('Please, enter a valid credit card verification number.'); ?>");
+  Translator.add('Please, select the number of installments.', "<?php echo $helper->__('Please, select the number of installments.'); ?>");
+  Translator.add('Please use only letters (a-z or A-Z), numbers (0-9) or spaces only in this field.', "<?php echo $helper->__('Please use only letters (a-z or A-Z), numbers (0-9) or spaces only in this field.'); ?>");
+  Translator.add('This is a required field.', "<?php echo $helper->__('This is a required field.') ?>")
+  Translator.add('Please use numbers only in this field. Please avoid spaces or other characters such as dots or commas.', "<?php echo $helper->__('Please use numbers only in this field. Please avoid spaces or other characters such as dots or commas.') ?>")
 
   let generateCardHashEvent = false
   let card

--- a/js/pagarme/creditcard.js
+++ b/js/pagarme/creditcard.js
@@ -13,12 +13,12 @@ function debounce(func, wait, immediate) {
   };
 };
 
-const getCardNumber = () => get('#pagarme_creditcard_creditcard_number').value
+const getCardNumber = () => get('#pagarme_creditcard_creditcard_number').value;
 
-const getCardExpirationDate = () => get('#pagarme_creditcard_creditcard_expiration_date').value
+const getCardExpirationDate = () => get('#pagarme_creditcard_creditcard_expiration_date').value;
 
 const isFilled = (input) => {
-  return input.type !== 'select-one' ? input.value.length >= 3 : true
+  return input.type !== 'select-one' ? input.value.length >= 3 : true;
 }
 
 const getCardData = () => {
@@ -27,7 +27,7 @@ const getCardData = () => {
     card_holder_name: get('#pagarme_creditcard_creditcard_owner').value,
     card_expiration_date: getCardExpirationDate().replace(/\s|\//g, ''),
     card_cvv: get('#pagarme_creditcard_creditcard_cvv').value,
-  }
+  };
 }
 
 const isValidCardExpirationDate = () => {
@@ -35,35 +35,35 @@ const isValidCardExpirationDate = () => {
    * The regex validates the following formats:
    * MMYY, MM/YY, MM / YY
    */
-  const validDateRegex = new RegExp(/\d{2}\s?\/?\s?\d{2}/)
+  const validDateRegex = new RegExp(/\d{2}\s?\/?\s?\d{2}/);
 
-  return validDateRegex.test(getCardExpirationDate())
+  return validDateRegex.test(getCardExpirationDate());
 }
 
 const shouldGenerateCardHash = (card) => {
   if (!pagarmeCreditcardSelected()){
-    return false
+    return false;
   }
 
-  const pagarmeInputsNodeList = document.querySelectorAll('.card-data input')
-  const pagarmeCardInputs = Array.from(pagarmeInputsNodeList)
+  const pagarmeInputsNodeList = document.querySelectorAll('.card-data input');
+  const pagarmeCardInputs = Array.from(pagarmeInputsNodeList);
 
   if (!pagarmeCardInputs.every(isFilled)) {
-    return false
+    return false;
   }
 
   const cardValidations = pagarme.validate({
     card
-  })
+  });
 
-  const { card_holder_name, card_cvv } = cardValidations.card
+  const { card_holder_name, card_cvv } = cardValidations.card;
 
-  return card_holder_name && card_cvv && isValidCardExpirationDate()
+  return card_holder_name && card_cvv && isValidCardExpirationDate();
 }
 
 const tryGenerateCardHash = debounce(() => {
   if (shouldGenerateCardHash(getCardData())) {
-    clearHash()
-    return generateHash(getCardData())
+    clearHash();
+    return generateHash(getCardData());
   }
-}, 600)
+}, 600);


### PR DESCRIPTION
### Descrição

Esse PR tem o intuito de evitar erros de Javascript ao utilizar, por exemplo, configurações de minificação de arquivos no Magento. Esses erros já foram encontrados em atendimentos e resolvidos com correções pontuais nesses arquivos.

Obs.: Também aproveito para ajustar o README onde consta a informação de cancelamento de pedidos de boleto após 4 dias, pois [nesse PR](https://github.com/pagarme/pagarme-magento/pull/372) antigo foi alterado para 7 dias mas não houve alteração no README.