### PR TITLE
 Ajuste da versão do módulo GuzzleHttp para versão minima 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4",
         "pagarme/pagarme-php": "^3.8",
-        "guzzlehttp/guzzle": "^5.3"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8",


### PR DESCRIPTION
Alterar a versão da biblioteca 'guzzlehttp/guzzle' para '^7.0'. Executar o comando 'composer install'.

Lembrando que este ajuste foi testado em um cenário onde o módulo da pagarme foi instalado de forma manual, conforme eles explicam na documentação.

É de sumo importância fazer um backup completo antes de executar qualquer comando.

### Descrição

<!Insira aqui o contexto/motivo deste Pull Request.>

### Número da Issue

<!Insira aqui o número da Issue referente à este Pull Request.>

### Testes Realizados

<!Descreva aqui todos os detalhes realizados para assegurar o Pull Request. Coloque todos os dados possíveis: versões dos recursos, módulos extras adicionados ao teste :)>

<!NÃO SE ESQUEÇA DE: Marcar um dos desenvolvedores do Pagar.me para review.>
